### PR TITLE
Fix build problems

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "env": {
     "build": {
-      "presets": ["env", "flow"],
+      "presets": [["env", { "exclude": ["transform-regenerator"] }], "flow"],
       "plugins": ["transform-strip-jsnext"]
     },
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.1",
-    "babel-plugin-transform-strip-jsnext": "^2.0.0",
+    "babel-plugin-transform-strip-jsnext": "^2.0.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.26.0",


### PR DESCRIPTION
Fixed #41 

It has two errors in build process.

1. `dist/*.js` include regeneratorRuntime neither babel-polyfill nor transform-runtime
1. remain `/jsnext` in [this line](https://github.com/phenyl-js/phenyl/blob/master/modules/power-assign/src/index.js#L22)

I fixed these problems.

## Solutions
- [x] 1. Ignore preset `transform-regenerator`
- [x] 2. Fix transform bugs (see CureApp/babel-plugin-transform-strip-jsnext#16)