### PR TITLE
[phenyl-mongodb] Add update operation filter

### DIFF
--- a/modules/phenyl-interfaces/test-cases/index.js
+++ b/modules/phenyl-interfaces/test-cases/index.js
@@ -101,6 +101,7 @@ export const assertEntityClient = (
         })
 
         assert(result.ok === 1)
+        assert(result.entities.length > 0)
         result.entities.forEach(entity => {
           assert(entity.name.first === 'Shin')
         })
@@ -278,6 +279,7 @@ export const assertEntityClient = (
           where: { 'name.last': 'Tanaka' },
         })
 
+        assert(result2.entities.length > 0)
         result2.entities.forEach(entity => {
           assert(entity.favorites.music.singer === 'Tatsuro Yamashita')
         })
@@ -303,6 +305,7 @@ export const assertEntityClient = (
           where: { 'name.last': 'Tanaka' },
         })
 
+        assert(result2.entities.length > 0)
         result2.entities.forEach(entity => {
           assert(entity.skills.length > 0)
           assert(entity.favorites.music.writer === 'Tatsuro Yamashita')
@@ -356,6 +359,7 @@ export const assertEntityClient = (
 
         assert(result.ok === 1)
         assert(result.n === 7)
+        assert(result.entities.length > 0)
         result.entities.forEach(entity => {
           assert(entity.favorites.book.author === 'Abe Kobo')
         })

--- a/modules/phenyl-interfaces/test-cases/index.js
+++ b/modules/phenyl-interfaces/test-cases/index.js
@@ -236,6 +236,30 @@ export const assertEntityClient = (
 
         assert(result2.entity.favorites.music.singer === 'Tatsuro Yamashita')
       })
+
+      it ('rename an entity with updateById command', async () => {
+        const result = await entityClient.updateById({
+          entityName: 'user',
+          id: user1.id,
+          operation: {
+            $rename: {
+              hobbies: 'skills',
+              'favorites.music.singer': 'writer',
+            }
+          },
+        })
+
+        assert(result.ok === 1)
+        assert(result.n === 1)
+
+        const result2 = await entityClient.get({
+          entityName: 'user',
+          id: user1.id,
+        })
+
+        assert(result2.entity.skills.length === 1)
+        assert(result2.entity.favorites.music.writer === 'Tatsuro Yamashita')
+      })
     })
 
     describe('updateMulti', () => {
@@ -256,6 +280,32 @@ export const assertEntityClient = (
 
         result2.entities.forEach(entity => {
           assert(entity.favorites.music.singer === 'Tatsuro Yamashita')
+        })
+      })
+
+      it ('rename entities with updateMulti command', async () => {
+        const result = await entityClient.updateMulti({
+          entityName: 'user',
+          where: { 'name.last': 'Tanaka' },
+          operation: {
+            $rename: {
+              hobbies: 'skills',
+              'favorites.music.singer': 'writer',
+            }
+          },
+        })
+
+        assert(result.ok === 1)
+        assert(result.n === 7)
+
+        const result2 = await entityClient.find({
+          entityName: 'user',
+          where: { 'name.last': 'Tanaka' },
+        })
+
+        result2.entities.forEach(entity => {
+          assert(entity.skills.length > 0)
+          assert(entity.favorites.music.writer === 'Tatsuro Yamashita')
         })
       })
 

--- a/modules/phenyl-mongodb/test/mongodb-client.js
+++ b/modules/phenyl-mongodb/test/mongodb-client.js
@@ -3,9 +3,9 @@
 import { it, describe } from 'kocha'
 import assert from 'power-assert'
 import type { AndFindOperation } from 'phenyl-interfaces'
-import { filterWhere } from '../src/mongodb-client.js'
+import { filterFindOperation } from '../src/mongodb-client.js'
 
-describe('filterWhere', () => {
+describe('filterFindOperation', () => {
   it ('renames id to _id', () => {
     const input: AndFindOperation = {
       $and: [
@@ -19,7 +19,7 @@ describe('filterWhere', () => {
         { type: 'bar' },
       ]
     }
-    const actual = filterWhere(input)
+    const actual = filterFindOperation(input)
     assert.deepEqual(actual, expected)
   })
 
@@ -45,7 +45,7 @@ describe('filterWhere', () => {
         { type: 'bar' },
       ]
     }
-    const actual = filterWhere(input)
+    const actual = filterFindOperation(input)
     assert.deepEqual(actual, expected)
   })
 })

--- a/modules/phenyl-mongodb/test/mongodb-client.js
+++ b/modules/phenyl-mongodb/test/mongodb-client.js
@@ -2,8 +2,11 @@
 
 import { it, describe } from 'kocha'
 import assert from 'power-assert'
-import type { AndFindOperation } from 'phenyl-interfaces'
-import { filterFindOperation } from '../src/mongodb-client.js'
+import type { AndFindOperation, UpdateOperation } from 'phenyl-interfaces'
+import {
+  filterFindOperation,
+  filterUpdateOperation,
+} from '../src/mongodb-client.js'
 
 describe('filterFindOperation', () => {
   it ('renames id to _id', () => {
@@ -46,6 +49,27 @@ describe('filterFindOperation', () => {
       ]
     }
     const actual = filterFindOperation(input)
+    assert.deepEqual(actual, expected)
+  })
+})
+
+describe('filterUpdateOperation', () => {
+  it ('converts new name to name with parent', () => {
+    const input: UpdateOperation = {
+      $rename: {
+        foo: 'bar',
+        'baz.qux': 'foobar',
+        'baz.foo.qux': 'foobar',
+      }
+    }
+    const expected = {
+      $rename: {
+        foo: 'bar',
+        'baz.qux': 'baz.foobar',
+        'baz.foo.qux': 'baz.foo.foobar',
+      }
+    }
+    const actual = filterUpdateOperation(input)
     assert.deepEqual(actual, expected)
   })
 })


### PR DESCRIPTION
Add update operation filter to convert rename operation

from
```js
{ $rename: { 'parent.oldName' : 'newName' } } 
```
to
```js
{ $rename: { 'parent.oldName' : 'parent.newName' } } 
```

This PR closes #45 