### PR TITLE
[phenyl-redux] logout await request end

### DIFF
--- a/modules/phenyl-redux/src/middleware.js
+++ b/modules/phenyl-redux/src/middleware.js
@@ -234,7 +234,7 @@ export class MiddlewareHandler {
    */
   async logout(action: LogoutAction) {
     const command = action.payload
-    this.client.logout(command, this.sessionId) // No awaiting here.
+    await this.client.logout(command, this.sessionId)
     this.resetState()
   }
 


### PR DESCRIPTION
`logout` action must await request finished.

## Problem
- Client state: session exists
- Server state: session already expired

Unhandled promise rejection occurred when dispatch `logout` action.

## Solution
logout returns Promise to handle error response.
