### PR TITLE
Remove jsnext

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "env": {
     "build": {
       "presets": [["env", { "exclude": ["transform-regenerator"] }], "flow"],
-      "plugins": ["transform-strip-jsnext", "transform-class-properties"]
+      "plugins": ["transform-class-properties"]
     },
 
     "development": {

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ TBD
 ## ServerSide
 ```js
 // @flow
-import PhenylHttpServer from 'phenyl-http-server/jsnext'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
-import { connect, createEntityClient } from 'phenyl-mongodb/jsnext'
+import PhenylHttpServer from 'phenyl-http-server'
+import PhenylRestApi from 'phenyl-rest-api'
+import { connect, createEntityClient } from 'phenyl-mongodb'
 
 const connection = await connect('mongodb://localhost:12345')
 

--- a/examples/authentication/src/index.js
+++ b/examples/authentication/src/index.js
@@ -1,11 +1,11 @@
 // @flow
 /* eslint-disable no-console */
 import http from 'http'
-import PhenylHttpServer from 'phenyl-http-server/jsnext'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
-import PhenylHttpClient from 'phenyl-http-client/jsnext'
-import { createEntityClient } from 'phenyl-memory-db/jsnext'
-import { StandardUserDefinition } from 'phenyl-standards/jsnext'
+import PhenylHttpServer from 'phenyl-http-server'
+import PhenylRestApi from 'phenyl-rest-api'
+import PhenylHttpClient from 'phenyl-http-client'
+import { createEntityClient } from 'phenyl-memory-db'
+import { StandardUserDefinition } from 'phenyl-standards'
 
 const memoryClient = createEntityClient()
 

--- a/examples/express/src/index.js
+++ b/examples/express/src/index.js
@@ -1,14 +1,14 @@
 // @flow
 /* eslint-disable no-console */
 import express from 'express'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
-import PhenylHttpClient from 'phenyl-http-client/jsnext'
-import { createEntityClient } from 'phenyl-memory-db/jsnext'
-import { StandardUserDefinition } from 'phenyl-standards/jsnext'
+import PhenylRestApi from 'phenyl-rest-api'
+import PhenylHttpClient from 'phenyl-http-client'
+import { createEntityClient } from 'phenyl-memory-db'
+import { StandardUserDefinition } from 'phenyl-standards'
 import {
   createPhenylApiMiddleware,
   createPhenylMiddleware,
-} from 'phenyl-express/jsnext'
+} from 'phenyl-express'
 
 import type { FunctionalGroup } from 'phenyl-interfaces'
 

--- a/examples/redux/src/index.js
+++ b/examples/redux/src/index.js
@@ -3,12 +3,12 @@
 /* eslint-env node */
 import http from 'http'
 import { createStore, combineReducers, applyMiddleware } from 'redux'
-import { PhenylRedux, LocalStateFinder } from 'phenyl-redux/jsnext'
-import PhenylHttpServer from 'phenyl-http-server/jsnext'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
-import PhenylHttpClient from 'phenyl-http-client/jsnext'
-import { createEntityClient } from 'phenyl-memory-db/jsnext'
-import { StandardUserDefinition } from 'phenyl-standards/jsnext'
+import { PhenylRedux, LocalStateFinder } from 'phenyl-redux'
+import PhenylHttpServer from 'phenyl-http-server'
+import PhenylRestApi from 'phenyl-rest-api'
+import PhenylHttpClient from 'phenyl-http-client'
+import { createEntityClient } from 'phenyl-memory-db'
+import { StandardUserDefinition } from 'phenyl-standards'
 import type { FunctionalGroup } from 'phenyl-interfaces'
 
 type ThisEntityMap = {

--- a/modules/mongolike-operations/decls/update-operation.js.flow
+++ b/modules/mongolike-operations/decls/update-operation.js.flow
@@ -73,7 +73,7 @@ export type RenameOperator = {
  *   }
  *
  * 2) Use updateOperationToJSON() function exported from oad-utils
- *    import { updateOperationToJSON } from 'oad-utils/jsnext'
+ *    import { updateOperationToJSON } from 'oad-utils'
  *    const operation: UpdateOperation = { $restore: { foo: Foo } }
  *    JSON.stringify(updateOperationToJSON(operation)) // {"$restore":{"foo":""}}
  */

--- a/modules/oad-utils/README.md
+++ b/modules/oad-utils/README.md
@@ -16,10 +16,8 @@ npm install oad-utils
 ```
 
 ## Using types with flow
-For [Flow](https://flowtype.org) annotations, just use `/jsnext` entrypoint.
-
 ```js
-import { hasOwnNestedProperty, visitFindOperation } from 'oad-utils/jsnext'
+import { hasOwnNestedProperty, visitFindOperation } from 'oad-utils'
 ```
 
 All the interfaces are defined in the depending module [mongolike-operations](https://github.com/phenyl-js/phenyl/tree/master/modules/mongolike-operations).

--- a/modules/phenyl-central-state/src/session-client.js
+++ b/modules/phenyl-central-state/src/session-client.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   randomStringWithTimeStamp
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import type {
   Id,

--- a/modules/phenyl-central-state/src/versioning.js
+++ b/modules/phenyl-central-state/src/versioning.js
@@ -2,11 +2,11 @@
 import {
   normalizeUpdateOperation,
   mergeUpdateOperations,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 import {
   randomStringWithTimeStamp
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import type {
   Entity,

--- a/modules/phenyl-express/README.md
+++ b/modules/phenyl-express/README.md
@@ -19,10 +19,9 @@ npm install phenyl-express
 ```
 
 ## Using types with flow
-For [Flow](https://flowtype.org) annotations, just use `/jsnext` entrypoint.
 
 ```js
-import { createPhenylApiMiddleware } from 'phenyl-express/jsnext'
+import { createPhenylApiMiddleware } from 'phenyl-express'
 ```
 
 # API Documentation

--- a/modules/phenyl-express/src/index.js
+++ b/modules/phenyl-express/src/index.js
@@ -5,8 +5,8 @@ import {
   decodeRequest,
   getStatusCode,
   ServerLogic,
-} from 'phenyl-http-rules/jsnext'
-import { createServerError } from 'phenyl-utils/jsnext'
+} from 'phenyl-http-rules'
+import { createServerError } from 'phenyl-utils'
 
 import type {
   ServerParams,

--- a/modules/phenyl-express/test/index.js
+++ b/modules/phenyl-express/test/index.js
@@ -3,9 +3,9 @@
 import { it, describe, afterEach, beforeEach } from 'kocha'
 import assert from 'power-assert'
 import express from 'express'
-import PhenylHttpClient from 'phenyl-http-client/jsnext'
-import { createEntityClient } from 'phenyl-memory-db/jsnext'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
+import PhenylHttpClient from 'phenyl-http-client'
+import { createEntityClient } from 'phenyl-memory-db'
+import PhenylRestApi from 'phenyl-rest-api'
 import {
   createPhenylApiMiddleware,
   createPhenylMiddleware,

--- a/modules/phenyl-http-client/src/index.js
+++ b/modules/phenyl-http-client/src/index.js
@@ -3,11 +3,11 @@ import fp from 'fetch-ponyfill'
 import {
   encodeRequest,
   decodeResponse,
-} from 'phenyl-http-rules/jsnext'
+} from 'phenyl-http-rules'
 import {
   PhenylRestApiClient,
   createLocalError,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 const { fetch } = fp()
 
 import type {

--- a/modules/phenyl-http-client/test/index.js
+++ b/modules/phenyl-http-client/test/index.js
@@ -4,10 +4,10 @@ import kocha from 'kocha'
 import assert from 'power-assert'
 import PhenylHttpClient from '../src/index.js'
 import { assertEntityClient } from 'phenyl-interfaces/test-cases'
-import PhenylHttpServer from 'phenyl-http-server/jsnext'
+import PhenylHttpServer from 'phenyl-http-server'
 import { createServer } from 'http'
-import PhenylRestApi from 'phenyl-rest-api/jsnext'
-import { createEntityClient } from 'phenyl-memory-db/jsnext'
+import PhenylRestApi from 'phenyl-rest-api'
+import { createEntityClient } from 'phenyl-memory-db'
 
 const entityClient = createEntityClient()
 

--- a/modules/phenyl-http-rules/src/encode-request.js
+++ b/modules/phenyl-http-rules/src/encode-request.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   assertValidRequestData
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import type {
   EncodedHttpRequest,

--- a/modules/phenyl-http-rules/src/server-logic.js
+++ b/modules/phenyl-http-rules/src/server-logic.js
@@ -7,7 +7,7 @@ import encodeResponse from './encode-response.js'
 import {
   createServerError,
   PhenylRestApiDirectClient,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import type {
   RestApiClient,

--- a/modules/phenyl-http-server/src/index.js
+++ b/modules/phenyl-http-server/src/index.js
@@ -4,7 +4,7 @@
 import url from 'url'
 import {
   ServerLogic,
-} from 'phenyl-http-rules/jsnext'
+} from 'phenyl-http-rules'
 
 import type {
   IncomingMessage,

--- a/modules/phenyl-lambda-adapter/src/index.js
+++ b/modules/phenyl-lambda-adapter/src/index.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   ServerLogic,
-} from 'phenyl-http-rules/jsnext'
+} from 'phenyl-http-rules'
 
 import type {
   ServerParams,

--- a/modules/phenyl-memory-db/src/create-entity-client.js
+++ b/modules/phenyl-memory-db/src/create-entity-client.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   PhenylEntityClient,
-} from 'phenyl-central-state/jsnext'
+} from 'phenyl-central-state'
 
 import { PhenylMemoryDbClient } from './phenyl-memory-db-client.js'
 
@@ -10,7 +10,7 @@ import type {
   EntityState,
 } from 'phenyl-interfaces'
 
-import type { PhenylEntityClientOptions } from 'phenyl-central-state/jsnext'
+import type { PhenylEntityClientOptions } from 'phenyl-central-state'
 
 export type MemoryClientOptions<M: EntityMap> = {
   entityState?: EntityState<M>,

--- a/modules/phenyl-memory-db/src/kvs-client.js
+++ b/modules/phenyl-memory-db/src/kvs-client.js
@@ -1,12 +1,12 @@
 // @flow
-import { assignWithRestoration } from 'power-assign/jsnext'
+import { assignWithRestoration } from 'power-assign'
 import type {
   Entity,
   PreEntity,
   KvsClient,
   Id,
 } from 'phenyl-interfaces'
-import { randomString } from 'phenyl-utils/jsnext'
+import { randomString } from 'phenyl-utils'
 
 interface KeyValuePool<T> {
   [id: Id]: T

--- a/modules/phenyl-memory-db/src/phenyl-memory-db-client.js
+++ b/modules/phenyl-memory-db/src/phenyl-memory-db-client.js
@@ -3,14 +3,14 @@
 import {
   PhenylStateFinder,
   PhenylStateUpdater,
-} from 'phenyl-state/jsnext'
+} from 'phenyl-state'
 import {
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 import {
   createServerError,
   randomStringWithTimeStamp,
-} from 'phenyl-utils/jsnext'
-import { assign } from 'power-assign/jsnext'
+} from 'phenyl-utils'
+import { assign } from 'power-assign'
 
 import type {
   PreEntity,

--- a/modules/phenyl-memory-db/test/phenyl-memory-client.js
+++ b/modules/phenyl-memory-db/test/phenyl-memory-client.js
@@ -2,7 +2,7 @@
 import { describe, it, before, beforeEach } from 'kocha'
 import assert from 'power-assert'
 import { createEntityClient } from '../src/create-entity-client.js'
-import { assign } from 'power-assign/jsnext'
+import { assign } from 'power-assign'
 
 function range(n, start) {
   return Array.from(Array(n + start).keys()).slice(start)

--- a/modules/phenyl-mongodb/src/create-entity-client.js
+++ b/modules/phenyl-mongodb/src/create-entity-client.js
@@ -1,9 +1,9 @@
 // @flow
 import type { EntityMap } from 'phenyl-interfaces'
-import { PhenylEntityClient } from 'phenyl-central-state/jsnext'
+import { PhenylEntityClient } from 'phenyl-central-state'
 import { PhenylMongoDbClient } from './mongodb-client.js'
 import type { MongoDbConnection } from './connection.js'
-import type { PhenylEntityClientOptions } from 'phenyl-central-state/jsnext'
+import type { PhenylEntityClientOptions } from 'phenyl-central-state'
 
 export function createEntityClient<M: EntityMap>(conn: MongoDbConnection, options: PhenylEntityClientOptions<M> = {}): PhenylMongoDbEntityClient<M> {
   return new PhenylMongoDbEntityClient(conn, options)

--- a/modules/phenyl-mongodb/src/mongodb-client.js
+++ b/modules/phenyl-mongodb/src/mongodb-client.js
@@ -3,12 +3,12 @@ import mongodb from 'mongodb'
 import bson from 'bson'
 import {
   createServerError,
-} from 'phenyl-utils/jsnext'
-import { assign } from 'power-assign/jsnext'
+} from 'phenyl-utils'
+import { assign } from 'power-assign'
 import {
   convertToDotNotationString,
   visitFindOperation,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 import type {
   Entity,

--- a/modules/phenyl-redux/src/local-state-updater.js
+++ b/modules/phenyl-redux/src/local-state-updater.js
@@ -2,11 +2,11 @@
 
 import {
   assign,
-} from 'power-assign/jsnext'
+} from 'power-assign'
 
 import {
   createLocalError,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import { removeOne } from './utils'
 

--- a/modules/phenyl-redux/src/phenyl-redux-module.js
+++ b/modules/phenyl-redux/src/phenyl-redux-module.js
@@ -1,11 +1,11 @@
 // @flow
 import {
   assign,
-} from 'power-assign/jsnext'
+} from 'power-assign'
 
 import {
   randomStringWithTimeStamp,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import type {
   AssignAction,

--- a/modules/phenyl-rest-api/src/phenyl-rest-api.js
+++ b/modules/phenyl-rest-api/src/phenyl-rest-api.js
@@ -3,7 +3,7 @@ import {
   assertValidRequestData,
   createServerError,
   PhenylRestApiDirectClient
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import {
   passThroughHandler,

--- a/modules/phenyl-standards/src/encrypt-password-in-request-data.js
+++ b/modules/phenyl-standards/src/encrypt-password-in-request-data.js
@@ -8,9 +8,9 @@ import type {
   EncryptFunction,
 } from '../decls/index.js.flow'
 
-import { getNestedValue } from 'oad-utils/jsnext'
+import { getNestedValue } from 'oad-utils'
 
-import { assign } from 'power-assign/jsnext'
+import { assign } from 'power-assign'
 
 
 export function encryptPasswordInRequestData(reqData: RequestData, passwordPropName: DocumentPath, encrypt: EncryptFunction): RequestData {

--- a/modules/phenyl-standards/src/foreign-query-wrapper.js
+++ b/modules/phenyl-standards/src/foreign-query-wrapper.js
@@ -1,15 +1,15 @@
 // @flow
 import {
   assign,
-} from 'power-assign/jsnext'
+} from 'power-assign'
 import {
   switchByRequestMethod,
   assertValidEntityName,
   assertNonEmptyString,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 import {
   getNestedValue,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 import type {
   Entity,
   EntityMap,

--- a/modules/phenyl-standards/src/remove-password-from-response-data.js
+++ b/modules/phenyl-standards/src/remove-password-from-response-data.js
@@ -1,15 +1,15 @@
 // @flow
 import {
   hasOwnNestedProperty,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 import {
   visitEntitiesInResponseData,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import {
   assign,
-} from 'power-assign/jsnext'
+} from 'power-assign'
 
 import type {
   ResponseData,

--- a/modules/phenyl-standards/src/standard-user-definition.js
+++ b/modules/phenyl-standards/src/standard-user-definition.js
@@ -1,9 +1,9 @@
 // @flow
 
-import powerCrypt from 'power-crypt/jsnext'
+import powerCrypt from 'power-crypt'
 import {
   createServerError,
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import { StandardEntityDefinition } from './standard-entity-definition.js'
 import { encryptPasswordInRequestData } from './encrypt-password-in-request-data.js'

--- a/modules/phenyl-standards/test/encrypt-password-in-request-data.js
+++ b/modules/phenyl-standards/test/encrypt-password-in-request-data.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { it, describe } from 'kocha'
-import powerCrypt from 'power-crypt/jsnext'
+import powerCrypt from 'power-crypt'
 import assert from 'power-assert'
 import { encryptPasswordInRequestData } from '../src/encrypt-password-in-request-data.js'
 

--- a/modules/phenyl-state/src/phenyl-state-finder.js
+++ b/modules/phenyl-state/src/phenyl-state-finder.js
@@ -1,6 +1,6 @@
 // @flow
-import { sortByNotation } from 'oad-utils/jsnext'
-import { filter } from 'power-filter/jsnext'
+import { sortByNotation } from 'oad-utils'
+import { filter } from 'power-filter'
 
 import type {
   EntityMap,

--- a/modules/phenyl-state/src/phenyl-state-updater.js
+++ b/modules/phenyl-state/src/phenyl-state-updater.js
@@ -3,7 +3,7 @@
 import {
   retargetToProp,
   mergeOperations,
-} from 'power-assign/jsnext'
+} from 'power-assign'
 
 import type {
   DeleteCommand,

--- a/modules/phenyl-state/test/index.js
+++ b/modules/phenyl-state/test/index.js
@@ -3,7 +3,7 @@
 import { describe, it } from 'kocha'
 import assert from 'assert'
 import { PhenylState } from '../src/index.js'
-import { assignWithRestoration } from 'power-assign/jsnext'
+import { assignWithRestoration } from 'power-assign'
 
 describe('find', () => {
   it('', () => {

--- a/modules/phenyl-utils/src/visit-entities-in-response-data.js
+++ b/modules/phenyl-utils/src/visit-entities-in-response-data.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   assign
-} from 'power-assign/jsnext'
+} from 'power-assign'
 
 import type {
   Entity,

--- a/modules/phenyl-websocket-client/src/index.js
+++ b/modules/phenyl-websocket-client/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import WebSocket from './websocket.js'
-import { randomStringWithTimeStamp } from 'phenyl-utils/jsnext'
+import { randomStringWithTimeStamp } from 'phenyl-utils'
 
 import type {
   Id,

--- a/modules/phenyl-websocket-server/src/websocket-server.js
+++ b/modules/phenyl-websocket-server/src/websocket-server.js
@@ -5,7 +5,7 @@ import WebSocket from 'ws'
 
 import {
   createServerError
-} from 'phenyl-utils/jsnext'
+} from 'phenyl-utils'
 
 import WebSocketClientInfo from './client-info.js'
 

--- a/modules/power-assign/README.md
+++ b/modules/power-assign/README.md
@@ -26,10 +26,9 @@ npm install power-assign
 ```
 
 ## Using types with flow
-For [Flow](https://flowtype.org) annotations, just use `/jsnext` entrypoint.
 
 ```js
-import { assign } from 'power-assign/jsnext'
+import { assign } from 'power-assign'
 ```
 
 All the interfaces are defined in the depending module [mongolike-operations](https://github.com/phenyl-js/phenyl/tree/master/modules/mongolike-operations).

--- a/modules/power-assign/src/get-objects-to-be-assigned.js
+++ b/modules/power-assign/src/get-objects-to-be-assigned.js
@@ -4,7 +4,7 @@ import type {
   DocumentPath,
   Restorable,
 } from 'mongolike-operations'
-import { parseDocumentPath } from 'oad-utils/jsnext'
+import { parseDocumentPath } from 'oad-utils'
 
 export function getObjectsToBeAssigned(obj: Restorable, docPath: DocumentPath): Array<Restorable> {
   const ret = [obj]

--- a/modules/power-assign/src/index.js
+++ b/modules/power-assign/src/index.js
@@ -19,6 +19,6 @@ export {
   mergeUpdateOperations as mergeOperations,
   updateOperationToJSON as toJSON,
   normalizeUpdateOperation as normalizeOperation,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 export default PowerAssign

--- a/modules/power-assign/src/power-assign.js
+++ b/modules/power-assign/src/power-assign.js
@@ -1,14 +1,14 @@
 // @flow
 
 import deepEqual from 'fast-deep-equal'
-import { checkCondition } from 'power-filter/jsnext'
+import { checkCondition } from 'power-filter'
 import {
   getNestedValue,
   sortByNotation,
   parseDocumentPath,
   createDocumentPath,
   normalizeUpdateOperation,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 import { retargetToProp } from './retarget-to-prop.js'
 import { getObjectsToBeAssigned } from './get-objects-to-be-assigned.js'
 

--- a/modules/power-assign/src/retarget-to-prop.js
+++ b/modules/power-assign/src/retarget-to-prop.js
@@ -1,7 +1,7 @@
 // @flow
 import {
   normalizeUpdateOperation,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 import type {
   RegularUpdateOperation,

--- a/modules/power-filter/README.md
+++ b/modules/power-filter/README.md
@@ -24,10 +24,9 @@ npm install power-filter
 ```
 
 ## Using types with flow
-For [Flow](https://flowtype.org) annotations, just use `/jsnext` entrypoint.
 
 ```js
-import { filter } from 'power-filter/jsnext'
+import { filter } from 'power-filter'
 ```
 
 All the interfaces are defined in the depending module [mongolike-operations](https://github.com/phenyl-js/phenyl/tree/master/modules/mongolike-operations).

--- a/modules/power-filter/src/index.js
+++ b/modules/power-filter/src/index.js
@@ -13,7 +13,7 @@ import type {
 import {
   normalizeQueryCondition,
   getNestedValue,
-} from 'oad-utils/jsnext'
+} from 'oad-utils'
 
 type Classified = {
   ok: Array<Object>,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-strip-jsnext": "^2.0.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-power-assert": "^1.0.0",

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -145,8 +145,8 @@ class CLI {
       let iterResult = iter.next()
       while (!iterResult.done) {
         const shellCommand = iterResult.value
-        runCommand(shellCommand)
-        iterResult = iter.next()
+        const shellResult = runCommand(shellCommand)
+        iterResult = iter.next(shellResult)
       }
       console.log(chalk.green(`[${phenylModule.name}] ✓ publish done.\n`))
     }

--- a/tools/cli.js
+++ b/tools/cli.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 import { join, dirname as dir } from 'path'
-import shell from 'shelljs'
+import { run as runCommand } from './lib/shell.js'
 import chalk from 'chalk'
 import fs from 'fs'
 import PhenylModuleGraph from './lib/phenyl-module-graph.js'
@@ -38,8 +38,8 @@ class CLI {
   clean() {
     for (const phenylModule of this.graph.phenylModules) {
       console.log(chalk.cyan(`\n[${phenylModule.name}] clean start.`))
-      const { command, args } = phenylModule.cleanCommand()
-      shell[command](...args)
+      const shellCommand = phenylModule.cleanCommand()
+      runCommand(shellCommand)
       console.log(chalk.green(`[${phenylModule.name}] ✓ clean done.`))
     }
   }
@@ -54,8 +54,8 @@ class CLI {
         const iter = phenylModule.testCommands(this.graph)
         let shellResult, iterResult = iter.next()
         while (!iterResult.done) {
-          const { command, args } = iterResult.value
-          shellResult = shell[command](...args)
+          const shellCommand = iterResult.value
+          shellResult = runCommand(shellCommand)
           iterResult = iter.next(shellResult)
         }
         const succeeded = iterResult.value
@@ -90,8 +90,8 @@ class CLI {
       const iter = phenylModule.installCommands(this.graph)
       let shellResult, iterResult = iter.next()
       while (!iterResult.done) {
-        const { command, args } = iterResult.value
-        shellResult = shell[command](...args)
+        const shellCommand = iterResult.value
+        shellResult = runCommand(shellCommand)
         iterResult = iter.next(shellResult)
       }
       console.log(chalk.green(`[${phenylModule.name}] ✓ install done.\n`))
@@ -100,8 +100,13 @@ class CLI {
 
   build() {
     for (const phenylModule of this.graph.phenylModules) {
-      const { command, args } = phenylModule.buildCommand()
-      shell[command](...args)
+      const iter = phenylModule.buildCommands()
+      let iterResult = iter.next()
+      while (!iterResult.done) {
+        const shellCommand = iterResult.value
+        const shellResult = runCommand(shellCommand)
+        iterResult = iter.next(shellResult)
+      }
     }
   }
 
@@ -126,7 +131,7 @@ class CLI {
   }
 
   publish(...moduleNames: Array<string>) {
-    const { stdout } = shell.exec('npm whoami')
+    const { stdout } = runCommand({ type: 'exec', args: ['npm whoami'] })
     if (stdout.trim() !== 'phenyl') {
       console.error('npm user must be "phenyl" to publish. Check your .npmrc')
       return
@@ -139,8 +144,8 @@ class CLI {
       const iter = phenylModule.publishCommands(this.graph)
       let iterResult = iter.next()
       while (!iterResult.done) {
-        const { command, args } = iterResult.value
-        shell[command](...args)
+        const shellCommand = iterResult.value
+        runCommand(shellCommand)
         iterResult = iter.next()
       }
       console.log(chalk.green(`[${phenylModule.name}] ✓ publish done.\n`))

--- a/tools/lib/shell.js
+++ b/tools/lib/shell.js
@@ -1,0 +1,38 @@
+// @flow
+import shell from 'shelljs'
+import fs from 'fs'
+
+export type ShellCommandType = 'cd' | 'mkdir' | 'exec' | 'ln' | 'rm' | 'test' | 'cat' | 'save'
+
+export type ShellCommand = {
+  type: ShellCommandType,
+  args: Array<string>,
+}
+
+export type ShellResult = {
+  code: number,
+  stdout: string,
+  stderr: string,
+}
+
+export function run(shellCommand: ShellCommand): ShellResult {
+  const { type, args } = shellCommand
+  if (type === 'save') {
+    return save(args[0], args[1])
+  }
+  let ret = shell[type](...args)
+
+  if (type === 'test') {
+    ret = { code: ret ? 0 : 1, stdout: '', stderr: '' }
+  }
+  return ret
+}
+
+function save(content: string, file: string): ShellResult {
+  fs.writeFileSync(file, content)
+  return {
+    code: 0,
+    stdout: '',
+    stderr: '',
+  }
+}


### PR DESCRIPTION
importing `/jsnext` is not necessary to import types by flowtype when we put `dist/index.js.flow`.
This PR add a script to automatically generate these files in each module.