### PR TITLE
Convert DocumentPath to DotNotationString in UpdateOperation before passing to MongoDB

### DIFF
--- a/modules/mongolike-operations/decls/update-operation.js.flow
+++ b/modules/mongolike-operations/decls/update-operation.js.flow
@@ -1,5 +1,4 @@
 // @flow
-import type { Restorable } from './restorable.js.flow' // Object
 import type {
   QueryCondition,
   EqCondition,
@@ -78,7 +77,7 @@ export type RenameOperator = {
  *    JSON.stringify(updateOperationToJSON(operation)) // {"$restore":{"foo":""}}
  */
 export type RestoreOperator = {
-  [field: DocumentPath]: '' | Class<Restorable>
+  [field: DocumentPath]: '' | Class<*>
 }
 
 export type RegularUpdateOperation = $Shape<{

--- a/modules/oad-utils/src/index.js
+++ b/modules/oad-utils/src/index.js
@@ -7,6 +7,7 @@ export { normalizeUpdateOperation } from './normalize-update-operation.js'
 export { mergeUpdateOperations } from './merge-update-operations.js'
 export { findOperationToJSON } from './find-operation-to-json.js'
 export { visitFindOperation } from './visit-find-operation.js'
+export { visitUpdateOperation } from './visit-update-operation.js'
 export {
   parseDocumentPath,
   convertToDotNotationString,

--- a/modules/oad-utils/src/visit-update-operation.js
+++ b/modules/oad-utils/src/visit-update-operation.js
@@ -1,0 +1,79 @@
+// @flow
+import {
+  normalizeUpdateOperation
+} from './normalize-update-operation.js'
+
+import type {
+  UpdateOperation,
+  UpdateOperator,
+  UpdateOperatorName,
+  SetOperator,
+  IncOperator,
+  MinOperator,
+  MaxOperator,
+  MulOperator,
+  AddToSetOperator,
+  PopOperator,
+  PullOperator,
+  PushOperator,
+  CurrentDateOperator,
+  BitOperator,
+  UnsetOperator,
+  RestoreOperator,
+  RenameOperator,
+} from 'mongolike-operations'
+
+export type UpdateOperationVisitor = {
+  operation?: (op: UpdateOperator) => UpdateOperator,
+  $set?: (op: SetOperator) => SetOperator,
+  $inc?: (op: IncOperator) => IncOperator,
+  $min?: (op: MinOperator) => MinOperator,
+  $max?: (op: MaxOperator) => MaxOperator,
+  $mul?: (op: MulOperator) => MulOperator,
+  $addToSet?: (op: AddToSetOperator) => AddToSetOperator,
+  $pop?: (op: PopOperator) => PopOperator,
+  $pull?: (op: PullOperator) => PullOperator,
+  $push?: (op: PushOperator) => PushOperator,
+  $currentDate?: (op: CurrentDateOperator) => CurrentDateOperator,
+  $bit?: (op: BitOperator) => BitOperator,
+  $unset?: (op: UnsetOperator) => UnsetOperator,
+  $restore?: (op: RestoreOperator) => RestoreOperator,
+  $rename?: (op: RenameOperator) => RenameOperator,
+}
+
+/**
+ * @public
+ * Modify FindOperation by passing visitor functions.
+ */
+export function visitUpdateOperation(uOp: Object, visitor: UpdateOperationVisitor): UpdateOperation {
+  return [
+    '$set', '$inc', '$min', '$max', '$mul',
+    '$addToSet', '$pop', '$pull', '$push',
+    '$currentDate','$bit', '$unset', '$restore',
+    '$rename'
+  ].reduce((acc, opName: UpdateOperatorName) =>
+    visitOp(acc, visitor, opName)
+    , normalizeUpdateOperation(uOp))
+}
+
+function visitOp<N: UpdateOperatorName>(uOp: UpdateOperation, visitor: UpdateOperationVisitor, opName: N): UpdateOperation {
+  if (uOp[opName] == null) {
+    return uOp
+  }
+
+  let ret = Object.assign({}, uOp)
+  const generalVisitor = visitor.operation
+  if (generalVisitor != null) {
+    ret = Object.assign(ret, { [opName]: generalVisitor(ret[opName]) })
+  }
+  // $FlowIssue(compatible)
+  const specificVisitor: $ElementType<UpdateOperationVisitor, N> = visitor[opName]
+  if (specificVisitor != null) {
+    // $FlowIssue(compatible)
+    const op: $ElementType<UpdateOperation, N> = ret[opName]
+    // $FlowIssue(compatible)
+    ret = Object.assign(ret, { [opName]: specificVisitor(op) })
+  }
+  // $FlowIssue(compatible)
+  return ret
+}

--- a/modules/phenyl-interfaces/test-cases/index.js
+++ b/modules/phenyl-interfaces/test-cases/index.js
@@ -526,6 +526,24 @@ export const assertEntityClient = (
       assert(result2.entity.favorites && result2.entity.favorites.music.singer === 'Tatsuro Yamashita')
     })
 
+    it ('updates a property in array with updateById command', async () => {
+      const result = await entityClient.updateById({
+        entityName: 'user',
+        id: user1.id,
+        operation: { $set: { 'hobbies[0]': 'Jazz' }},
+      })
+
+      assert(result.ok === 1)
+      assert(result.n === 1)
+
+      const result2 = await entityClient.get({
+        entityName: 'user',
+        id: user1.id,
+      })
+
+      assert(result2.entity.hobbies && result2.entity.hobbies[0] === 'Jazz')
+    })
+
     it ('updates an entity by auto generated id', async () => {
       const result = await entityClient.updateById({
         entityName: 'user',

--- a/tools/src/cli.js
+++ b/tools/src/cli.js
@@ -145,6 +145,7 @@ class CLI {
     switch (message.type) {
       case 'message': {
         const { color, text } = message.payload
+        // $FlowIssue(chalk[color])
         console.log(color ? chalk[color](text) : text)
         break
       }


### PR DESCRIPTION
MongoDB doesn't support DocumentPath like `foo[1]`, should be converted into `foo.1`. Before passing operations to mongo, convert all the document paths in update operations.
