### PR TITLE
[phenyl-http-client] Tricky workaround for use in React Native

### DIFF
--- a/modules/phenyl-http-client/src/fetch.js
+++ b/modules/phenyl-http-client/src/fetch.js
@@ -1,2 +1,14 @@
 // @flow
-export { default } from 'node-fetch'
+
+/**
+ * This is the tricky workaround for Metro bundler (used in React Native).
+ * As Metro bundler doesn't see "browser" field in package.json, which otherwise switch the file from "fetch.js"
+ * to "fetch-browser.js" when "fetch.js" is required. Then, Metro bundler parses this file and try to bundle
+ * "node-fetch", which is intended to run only on Node.js. Metro bundler is wise enough to see the strings passed to
+ * require function. For Metro bundler not to follow the module name, generating the string programatically like
+ * `join('-')` is needed.
+ */
+const moduleName = ['node', 'fetch'].join('-')
+
+// $FlowIssue(fetch-maybe-globally-assigned)
+export default typeof fetch === 'undefined' ? require(moduleName) : fetch

--- a/modules/phenyl-http-client/src/index.js
+++ b/modules/phenyl-http-client/src/index.js
@@ -96,7 +96,7 @@ export default class PhenylHttpClient<TM: TypeMap> extends PhenylRestApiClient<T
    * @public
    * Access to Phenyl Server (CustomRequestHandler)
    */
-  async requestText(path: string, params: ?Object): Promise<string> {
+  async requestText(path: string, params?: Object): Promise<string> {
     const result = await fetch(this.url + path, params)
     return result.text()
   }


### PR DESCRIPTION
This is the tricky workaround for Metro bundler (used in React Native).
As Metro bundler doesn't see "browser" field in package.json, which otherwise switch the file from "fetch.js" to "fetch-browser.js" when "fetch.js" is required. Then, Metro bundler parses this file and try to bundle "node-fetch", which is intended to run only on Node.js. Metro bundler is wise enough to see the strings passed to require function. For Metro bundler not to follow the module name, generating the string programatically like `join('-')` is needed.