### PR TITLE
make getAll do not throw error when nothing to response

### DIFF
--- a/modules/phenyl-state/src/phenyl-state-finder.js
+++ b/modules/phenyl-state/src/phenyl-state-finder.js
@@ -72,7 +72,7 @@ export default class PhenylStateFinder<M: EntityMap> implements EntityStateFinde
   static getAll<N: $Keys<M>>(state: EntityState<M>, entityName: N): Array<$ElementType<M, N>> {
     const pool = state.pool[entityName]
     if (pool == null) {
-      throw new Error(`entityName: "${entityName}" is not found.`)
+      return []
     }
     return Object.keys(pool).map(key => pool[key])
   }


### PR DESCRIPTION
When phenyl-state-finder#getAll have nothing to response, and throw Error.
But we use it when it have nothing to response.
I expect `getAll` response empty array.

example: On test or development, system check "something inserted?"

