### PR TITLE
Disable polyfill when using React Native with debugger-ui

### DIFF
--- a/modules/phenyl-http-client/global-fetch.js
+++ b/modules/phenyl-http-client/global-fetch.js
@@ -1,0 +1,1 @@
+export default fetch

--- a/modules/phenyl-http-client/package.json
+++ b/modules/phenyl-http-client/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "./dist/index.js",
   "jsnext:main": "./jsnext.js",
+  "react-native": {
+    "cross-fetch": "./global-fetch.js"
+  },
   "scripts": {
     "test": "nyc mocha test/*.js --color always"
   },


### PR DESCRIPTION
An error occurred when using React Native with debugger-ui.
Error: `fetch is not a function`
