### PR TITLE
useEntities() for initializing redux state's entity fields

### DIFF
--- a/examples/redux/src/index.js
+++ b/examples/redux/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable no-console */
 /* eslint-env node */
+import assert from 'assert'
 import http from 'http'
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { PhenylRedux, LocalStateFinder } from 'phenyl-redux/jsnext'
@@ -12,7 +13,7 @@ import { StandardUserDefinition } from 'phenyl-standards/jsnext'
 import type { FunctionalGroup } from 'phenyl-interfaces'
 
 type ThisEntityMap = {
-  patient: { id: string, name: string, email: string, password?: string }
+  patient: { id: string, name: string, email: string, password?: string },
 }
 
 type ThisTypeMap = {
@@ -98,6 +99,22 @@ async function main() {
 
   const { session } = store.getState().phenyl
   if (!session) throw new Error('No session')
+
+  store.dispatch(
+    actions.useEntities(['patient', 'dummy001', 'dummy002'])
+  )
+  const entities = store.getState().phenyl.entities
+  console.log(entities)
+  assert(Object.keys(entities.patient).length === 1)
+  // $FlowIssue(dummy)
+  assert(entities.dummy001)
+  // $FlowIssue(dummy)
+  assert(entities.dummy002)
+  // $FlowIssue(dummy)
+  assert(Object.keys(entities.dummy001).length === 0)
+  // $FlowIssue(dummy)
+  assert(Object.keys(entities.dummy002).length === 0)
+
 
   store.dispatch(actions.logout({
     entityName: 'patient',

--- a/modules/phenyl-interfaces/decls/action.js.flow
+++ b/modules/phenyl-interfaces/decls/action.js.flow
@@ -73,6 +73,12 @@ export type ResetAction = {|
   tag: ActionTag,
 |}
 
+export type UseEntitiesAction = {|
+  type: 'phenyl/useEntities',
+  payload: Array<EntityName>,
+  tag: ActionTag,
+|}
+
 export type CommitAndPushAction<N: EntityName> = {|
   type: 'phenyl/commitAndPush',
   payload: IdUpdateCommand<N>,
@@ -164,4 +170,5 @@ export type PhenylAction<M: EntityMap, AM: AuthCommandMap> =
   PushAndCommitAction<$Keys<M>> |
   SetSessionAction |
   UnfollowAction<$Keys<M>> |
-  UnsetSessionAction
+  UnsetSessionAction |
+  UseEntitiesAction

--- a/modules/phenyl-interfaces/index.js
+++ b/modules/phenyl-interfaces/index.js
@@ -19,6 +19,7 @@ import type {
   SetSessionAction,
   UnfollowAction,
   UnsetSessionAction,
+  UseEntitiesAction,
 } from './decls/action.js.flow'
 
 import type {
@@ -453,6 +454,7 @@ export type {
   UpdateMultiResponseData,
   UpdateOneRequestData,
   UpdateOneResponseData,
+  UseEntitiesAction,
   UserDefinition,
   UserDefinitions,
   UserEntityNameOf,

--- a/modules/phenyl-redux/src/local-state-finder.js
+++ b/modules/phenyl-redux/src/local-state-finder.js
@@ -24,6 +24,13 @@ export class LocalStateFinder<TM: TypeMap> {
   /**
    * Check if LocalState has given id and entityName.
    */
+  static hasEntityField<N: EntityNameOf<TM>>(state: LocalStateOf<TM>, entityName: N): boolean {
+    return state.entities[entityName] != null
+  }
+
+  /**
+   * Check if LocalState has given id and entityName.
+   */
   static hasEntity<N: EntityNameOf<TM>>(state: LocalStateOf<TM>, query: IdQuery<N>): boolean {
     const { entityName, id } = query
     if (!state.entities[entityName]) return false

--- a/modules/phenyl-redux/src/local-state-updater.js
+++ b/modules/phenyl-redux/src/local-state-updater.js
@@ -40,6 +40,17 @@ export class LocalStateUpdater<TM: TypeMap> {
   static LocalStateFinder: Class<LocalStateFinder<TM>> = LocalStateFinder
 
   /**
+   * Initialize the given entity field.
+   */
+  static initialize<N: EntityNameOf<TM>>(state: LocalStateOf<TM>, entityName: N): UpdateOperation {
+    return {
+      $set: {
+        [createDocumentPath('entities', entityName)]: {}
+      }
+    }
+  }
+
+  /**
    * Commit the operation of entity to LocalState.
    * Error is thrown when no entity is registered.
    */

--- a/modules/phenyl-redux/src/phenyl-redux-module.js
+++ b/modules/phenyl-redux/src/phenyl-redux-module.js
@@ -14,6 +14,7 @@ import type {
   CredentialsOf,
   DeleteAction,
   Entity,
+  EntityName,
   EntityMapOf,
   EntityNameOf,
   EntityOf,
@@ -40,6 +41,7 @@ import type {
   UnfollowAction,
   UnsetSessionAction,
   UpdateOperation,
+  UseEntitiesAction,
   UserEntityNameOf,
 } from 'phenyl-interfaces'
 
@@ -82,6 +84,14 @@ export class PhenylReduxModule<TM: TypeMap> {
     return {
       type: 'phenyl/replace',
       payload: state,
+      tag: randomStringWithTimeStamp(),
+    }
+  }
+
+  static useEntities(entityNames: Array<EntityName>): UseEntitiesAction {
+    return {
+      type: 'phenyl/useEntities',
+      payload: entityNames,
       tag: randomStringWithTimeStamp(),
     }
   }


### PR DESCRIPTION
Added `useEntities()` action to redux module. The purpose is to avoid lackness of fields of one entityName when no entities are registered to the name.