### PR TITLE
Add action creators online and offline

### DIFF
--- a/modules/phenyl-interfaces/decls/action.js.flow
+++ b/modules/phenyl-interfaces/decls/action.js.flow
@@ -149,6 +149,16 @@ export type UnsetSessionAction = {|
   tag: ActionTag,
 |}
 
+export type OnlineAction = {|
+  type: 'phenyl/online',
+  tag: ActionTag,
+|}
+
+export type OfflineAction = {|
+  type: 'phenyl/offline',
+  tag: ActionTag,
+|}
+
 export type PhenylAction<M: EntityMap, AM: AuthCommandMap> =
   AssignAction |
   ReplaceAction<M> |
@@ -164,4 +174,6 @@ export type PhenylAction<M: EntityMap, AM: AuthCommandMap> =
   PushAndCommitAction<$Keys<M>> |
   SetSessionAction |
   UnfollowAction<$Keys<M>> |
-  UnsetSessionAction
+  UnsetSessionAction |
+  OnlineAction |
+  OfflineAction

--- a/modules/phenyl-interfaces/index.js
+++ b/modules/phenyl-interfaces/index.js
@@ -19,6 +19,8 @@ import type {
   SetSessionAction,
   UnfollowAction,
   UnsetSessionAction,
+  OnlineAction,
+  OfflineAction,
 } from './decls/action.js.flow'
 
 import type {
@@ -392,6 +394,8 @@ export type {
   MultiUpdateCommandResult,
   MultiValuesCommandResult,
   NormalizedFunctionalGroup,
+  OfflineAction,
+  OnlineAction,
   OptionsOf,
   PatchAction,
   PathModifier,

--- a/modules/phenyl-redux/.nycrc
+++ b/modules/phenyl-redux/.nycrc
@@ -1,0 +1,12 @@
+{
+  "cache": true,
+  "exclude": ["jsnext.js", "test/**/*.js"],
+  "require": [
+    "babel-register"
+  ],
+  "reporter": [
+    "lcov",
+    "html",
+    "text"
+  ]
+}

--- a/modules/phenyl-redux/package.json
+++ b/modules/phenyl-redux/package.json
@@ -4,9 +4,13 @@
   "description": "",
   "main": "./dist/index.js",
   "jsnext:main": "./jsnext.js",
+  "scripts": {
+    "test": "nyc mocha test/*.js --color always"
+  },
   "devDependencies": {
+    "babel-register": "^6.24.1",
     "mocha": "^5.0.5",
-    "babel-register": "^6.24.1"
+    "nyc": "^11.6.0"
   },
   "files": [
     "src",

--- a/modules/phenyl-redux/src/middleware.js
+++ b/modules/phenyl-redux/src/middleware.js
@@ -76,6 +76,10 @@ export class MiddlewareCreator<TM: TypeMap> {
             return handler.unfollow(action)
           case 'phenyl/unsetSession':
             return handler.unsetSession()
+          case 'phenyl/online':
+            return handler.online()
+          case 'phenyl/offline':
+            return handler.offline()
           default:
             return next(action)
         }
@@ -343,6 +347,22 @@ export class MiddlewareHandler<TM: TypeMap, T> {
   async unsetSession(): Promise<T> {
     const { LocalStateUpdater } = this.constructor
     return this.assignToState(LocalStateUpdater.unsetSession())
+  }
+
+  /**
+   * Mark as online.
+   */
+  async online(): Promise<T> {
+    const { LocalStateUpdater } = this.constructor
+    return this.assignToState(LocalStateUpdater.online())
+  }
+
+  /**
+   * Mark as offline.
+   */
+  async offline(): Promise<T> {
+    const { LocalStateUpdater } = this.constructor
+    return this.assignToState(LocalStateUpdater.offline())
   }
 }
 

--- a/modules/phenyl-redux/src/phenyl-redux-module.js
+++ b/modules/phenyl-redux/src/phenyl-redux-module.js
@@ -35,6 +35,8 @@ import type {
   ReplaceAction,
   ResetAction,
   SetSessionAction,
+  OnlineAction,
+  OfflineAction,
   Session,
   TypeMap,
   UnfollowAction,
@@ -195,6 +197,20 @@ export class PhenylReduxModule<TM: TypeMap> {
     return {
       type: 'phenyl/logout',
       payload: command,
+      tag: randomStringWithTimeStamp(),
+    }
+  }
+
+  static online(): OnlineAction {
+    return {
+      type: 'phenyl/online',
+      tag: randomStringWithTimeStamp(),
+    }
+  }
+
+  static offline(): OfflineAction {
+    return {
+      type: 'phenyl/offline',
       tag: randomStringWithTimeStamp(),
     }
   }

--- a/modules/phenyl-redux/test/middleware.js
+++ b/modules/phenyl-redux/test/middleware.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+import assert from 'assert'
+import { createMiddleware } from '../src/middleware'
+import { actions } from '../src/phenyl-redux-module'
+
+describe('MiddlewareCreator', () => {
+  describe('create', () => {
+    const createMockStore = (phenylState) => ({
+      getState() {
+        return {
+          phenyl: phenylState,
+        }
+      }
+    })
+    const middleware = createMiddleware({
+      storeKey: 'phenyl',
+      client: null
+    })
+
+    describe('Action phenyl/online', () => {
+      it('Dispatch an operation that make isOnline to true', async () => {
+        const expected = {
+          type: 'phenyl/assign',
+          payload: [
+            { '$set': { 'network.isOnline': true } }
+          ],
+        }
+
+        const store = createMockStore({})
+        const next = ({ type, payload }) => assert.deepStrictEqual(expected, { type, payload })
+        await middleware(store)(next)(actions.online())
+      })
+    })
+    describe('Action phenyl/offline', () => {
+      it('Dispatch an operation that make isOnline to false', async () => {
+        const expected = {
+          type: 'phenyl/assign',
+          payload: [
+            { '$set': { 'network.isOnline': false } }
+          ],
+        }
+
+        const store = createMockStore({})
+        const next = ({ type, payload }) => assert.deepStrictEqual(expected, { type, payload })
+        await middleware(store)(next)(actions.offline())
+      })
+    })
+  })
+})


### PR DESCRIPTION
Added two action creators.

- `online`
- `offline`

These operations are already defined in LocalStateUpdater(src/local-state-updater.js).
However, action creators corresponding to operation did not exist.
So I added action creators that can call these operations from userland.