### PR TITLE
explorer: change default payload

### DIFF
--- a/modules/phenyl-api-explorer-client/src/UIMeta.js
+++ b/modules/phenyl-api-explorer-client/src/UIMeta.js
@@ -8,7 +8,7 @@ export const operations = [
     availableOnHttp: true,
     // availableOnWebsocket: false,
     defaultPayload: {
-      where: [],
+      where: {},
       limit: 5,
     },
   },
@@ -20,7 +20,7 @@ export const operations = [
     availableOnHttp: true,
     // availableOnWebsocket: false,
     defaultPayload: {
-      where: [],
+      where: {},
     },
   },
   {
@@ -127,7 +127,7 @@ export const operations = [
     availableOnHttp: true,
     // availableOnWebsocket: false,
     defaultPayload: {
-      where: [],
+      where: {},
       operation: {
         xxx: 0,
       },
@@ -155,7 +155,7 @@ export const operations = [
     availableOnHttp: true,
     // availableOnWebsocket: false,
     defaultPayload: {
-      where: [],
+      where: {},
       operation: {
         xxx: 0,
       },


### PR DESCRIPTION
Modified the default payload in Phenyl api explorer from array to object.
This enables users to perform a query in a correct format without deleting the array first.