### PR TITLE
modify phenyl-explorer to that set customized url for PhenylHttpClient

### DIFF
--- a/modules/phenyl-api-explorer-client/scripts/prepare-assets.js
+++ b/modules/phenyl-api-explorer-client/scripts/prepare-assets.js
@@ -44,9 +44,12 @@ $('script[src]').each((i, el) => {
 })
 
 // Inject entities
-const phenylFunctionalGroupSkeleton = cheerio('<script></script>').text(`
-  window.PhenylFunctionalGroupSkeleton = <%- JSON.stringify(functionalGroup) %>
+const phenylApiExplorerClientGlobals = cheerio('<script></script>').text(`
+  window.phenylApiExplorerClientGlobals = {
+    phenylApiUrlBase: "<%- phenylApiUrlBase %>",
+    PhenylFunctionalGroupSkeleton: <%- JSON.stringify(functionalGroup) %>,
+  }
 `)
-$('script').eq(0).before(phenylFunctionalGroupSkeleton)
+$('script').eq(0).before(phenylApiExplorerClientGlobals)
 
 fs.writeFileSync(indexPath, $.html(), 'utf8')

--- a/modules/phenyl-api-explorer-client/src/containers/LoginModal.js
+++ b/modules/phenyl-api-explorer-client/src/containers/LoginModal.js
@@ -1,4 +1,4 @@
-/* global PhenylFunctionalGroupSkeleton */
+/* global phenylApiExplorerClientGlobals */
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { Message, Form, Button, Header, Icon, Modal } from 'semantic-ui-react'
@@ -17,6 +17,8 @@ type Props = {
 type State = {
 
 }
+
+const { PhenylFunctionalGroupSkeleton } = phenylApiExplorerClientGlobals
 
 class LoginModal extends Component<Props, State> {
   state = {

--- a/modules/phenyl-api-explorer-client/src/containers/Sidebar.js
+++ b/modules/phenyl-api-explorer-client/src/containers/Sidebar.js
@@ -1,4 +1,4 @@
-/* global PhenylFunctionalGroupSkeleton */
+/* global phenylApiExplorerClientGlobals */
 import React from 'react'
 import { Sidebar as SemanticSidebar, Menu } from 'semantic-ui-react'
 import { connect } from 'react-redux'
@@ -12,6 +12,8 @@ type Props = {
   userName: string,
   logout: () => void,
 }
+
+const { PhenylFunctionalGroupSkeleton } = phenylApiExplorerClientGlobals
 
 export const Sidebar = ({ version, userName, logout }: Props) => (
   <SemanticSidebar as={Menu} visible icon='labeled' vertical inverted className="fixed">

--- a/modules/phenyl-api-explorer-client/src/lib/phenylClient.js
+++ b/modules/phenyl-api-explorer-client/src/lib/phenylClient.js
@@ -1,0 +1,14 @@
+/* global phenylApiExplorerClientGlobals */
+import PhenylHttpClient from 'phenyl-http-client'
+
+const { phenylApiUrlBase } = phenylApiExplorerClientGlobals
+
+// singleton
+let client = null
+
+export default function getPhenylHttpClient() {
+  if (client) {
+    client = new PhenylHttpClient({ url: phenylApiUrlBase || window.location.origin })
+  }
+  return client
+}

--- a/modules/phenyl-api-explorer-client/src/modules/operation.js
+++ b/modules/phenyl-api-explorer-client/src/modules/operation.js
@@ -1,5 +1,5 @@
-import PhenylHttpClient from 'phenyl-http-client'
 import type { PhenylError } from 'phenyl-interfaces'
+import getPhenylHttpClient from '../lib/phenylClient'
 
 const EXECUTE_START = 'operation/EXECUTE_START'
 const EXECUTE_FINISHED = 'operation/EXECUTE_FINISHED'
@@ -56,7 +56,7 @@ export const receiveErrorResponse = (error: PhenylError, spent: number) => ({
 })
 
 export const execute = ({ sessionId, entityName, method, payload: payloadStr }) => async (dispatch) => {
-  const client = new PhenylHttpClient({ url: window.location.origin })
+  const client = getPhenylHttpClient()
   dispatch(startExecute())
 
   const start = new Date()
@@ -139,7 +139,7 @@ export const execute = ({ sessionId, entityName, method, payload: payloadStr }) 
 }
 
 export const runCustomQuery = ({ sessionId, name, params: paramsStr }) => async (dispatch) => {
-  const client = new PhenylHttpClient({ url: window.location.origin })
+  const client = getPhenylHttpClient()
   dispatch(startExecute())
 
   const start = new Date()
@@ -153,7 +153,7 @@ export const runCustomQuery = ({ sessionId, name, params: paramsStr }) => async 
 }
 
 export const runCustomCommand = ({ sessionId, name, params: paramsStr }) => async (dispatch) => {
-  const client = new PhenylHttpClient({ url: window.location.origin })
+  const client = getPhenylHttpClient()
   dispatch(startExecute())
 
   const start = new Date()

--- a/modules/phenyl-api-explorer-client/src/modules/user.js
+++ b/modules/phenyl-api-explorer-client/src/modules/user.js
@@ -1,5 +1,5 @@
 /* global PhenylFunctionalGroupSkeleton */
-import PhenylHttpClient from 'phenyl-http-client'
+import getPhenylHttpClient from '../lib/phenylClient'
 
 const LOGIN = 'user/LOGIN'
 const LOGIN_AS_ANONYMOUS = 'user/LOGIN_AS_ANONYMOUS'
@@ -68,7 +68,7 @@ export const reducer = (state = initialState, action) => {
 }
 
 export const login = (entityName, credentials) => async (dispatch) => {
-  const client = new PhenylHttpClient({ url: window.location.origin })
+  const client = getPhenylHttpClient()
 
   try {
     dispatch(loginRequest())

--- a/modules/phenyl-api-explorer-client/src/modules/user.js
+++ b/modules/phenyl-api-explorer-client/src/modules/user.js
@@ -1,4 +1,4 @@
-/* global PhenylFunctionalGroupSkeleton */
+/* global phenylApiExplorerClientGlobals */
 import getPhenylHttpClient from '../lib/phenylClient'
 
 const LOGIN = 'user/LOGIN'
@@ -8,6 +8,7 @@ const LOGIN_SUCCESS = 'user/LOGIN_SUCCESS'
 const LOGIN_FAILED = 'user/LOGIN_FAILED'
 const LOGOUT = 'user/LOGOUT'
 
+const { PhenylFunctionalGroupSkeleton } = phenylApiExplorerClientGlobals
 const initialState = {
   busy: false,
   displayName: '',

--- a/modules/phenyl-api-explorer/src/PhenylApiExplorer.js
+++ b/modules/phenyl-api-explorer/src/PhenylApiExplorer.js
@@ -11,17 +11,20 @@ import { shallowMap, pkgDir } from './utils'
 
 export type ExplorerParams = {|
   path: string,
+  phenylApiUrlBase: string,
 |}
 
 export default class PhenylApiExplorer {
   functionalGroup: FunctionalGroup;
   path: string;
+  phenylApiUrlBase: string;
   handler: any;
   html: string;
 
   constructor (functionalGroup: FunctionalGroup, params: ExplorerParams) {
     this.functionalGroup = functionalGroup
     this.path = params.path
+    this.phenylApiUrlBase = params.phenylApiUrlBase || ''
     this.handler = this.handler.bind(this)
     this.html = this.getClientHtml()
   }
@@ -30,6 +33,7 @@ export default class PhenylApiExplorer {
     const templatePath = path.join(pkgDir('phenyl-api-explorer-client'), 'build', 'index.html')
     const template = fs.readFileSync(templatePath, 'utf8')
     const data = {
+      phenylApiUrlBase: this.phenylApiUrlBase,
       functionalGroup: {
         users: shallowMap(this.functionalGroup.users, ({ accountPropName, passwordPropName }) => {
           if (!accountPropName || !passwordPropName) {

--- a/modules/phenyl-api-explorer/src/PhenylApiExplorer.js
+++ b/modules/phenyl-api-explorer/src/PhenylApiExplorer.js
@@ -11,7 +11,7 @@ import { shallowMap, pkgDir } from './utils'
 
 export type ExplorerParams = {|
   path: string,
-  phenylApiUrlBase: string,
+  phenylApiUrlBase?: string,
 |}
 
 export default class PhenylApiExplorer {


### PR DESCRIPTION
Currently, phenyl-explorer call api with 
`https://{domain}/api/hoge/fuga`.

But, It is necessary to be able to change urlBase like that
`https://{domain}/v1/phenyl/api/hoge/fuga` .

This is it.