### PR TITLE
feat: separate EntityClient to RawEntityClient and NormalizedEntityCl…

### DIFF
--- a/modules/interfaces/src/client.ts
+++ b/modules/interfaces/src/client.ts
@@ -3,8 +3,6 @@ import {
   AuthCommandMapOf,
   AuthCredentials,
   AuthSessions,
-  RequestEntity,
-  ReqResEntityMapOf,
   CustomCommandMapOf,
   CustomCommandParams,
   CustomCommandResultValue,
@@ -15,6 +13,8 @@ import {
   GeneralCustomMap,
   GeneralReqResEntityMap,
   GeneralTypeMap,
+  ReqResEntityMapOf,
+  RequestEntity,
   ResponseAuthUser,
   ResponseEntity
 } from "./type-map";
@@ -49,91 +49,142 @@ import {
   QueryResult,
   SingleQueryResult
 } from "./query-result";
-
 import { Key } from "./utils";
 import { KvsClient } from "./kvs-client";
 import { PreEntity } from "./entity";
 import { RestApiHandler } from "./rest-api-handler";
 
-export interface EntityClient<
+export type EntityClient<
+  M extends GeneralReqResEntityMap = GeneralReqResEntityMap
+> = RawEntityClient<M> | NormalizedEntityClient<M>;
+export interface RawEntityClient<
   M extends GeneralReqResEntityMap = GeneralReqResEntityMap
 > {
   find<EN extends Key<M>>(
     query: WhereQuery<EN>,
     sessionId?: string | null
   ): Promise<QueryResult<ResponseEntity<M, EN>>>;
-
   findOne<EN extends Key<M>>(
     query: WhereQuery<EN>,
     sessionId?: string | null
   ): Promise<SingleQueryResult<ResponseEntity<M, EN>>>;
-
   get<EN extends Key<M>>(
     query: IdQuery<EN>,
     sessionId?: string | null
   ): Promise<SingleQueryResult<ResponseEntity<M, EN>>>;
-
   getByIds<EN extends Key<M>>(
     query: IdsQuery<EN>,
     sessionId?: string | null
   ): Promise<QueryResult<ResponseEntity<M, EN>>>;
-
   pull<EN extends Key<M>>(
     query: PullQuery<EN>,
     sessionId?: string | null
   ): Promise<PullQueryResult<ResponseEntity<M, EN>>>;
-
   insertOne<EN extends Key<M>>(
-    command: SingleInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    command: SingleInsertCommand<EN, PreEntity<ResponseEntity<M, EN>>>,
     sessionId?: string | null
   ): Promise<SingleInsertCommandResult>;
-
   insertMulti<EN extends Key<M>>(
-    command: MultiInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    command: MultiInsertCommand<EN, PreEntity<ResponseEntity<M, EN>>>,
     sessionId?: string | null
   ): Promise<MultiInsertCommandResult>;
-
   insertAndGet<EN extends Key<M>>(
-    command: SingleInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    command: SingleInsertCommand<EN, PreEntity<ResponseEntity<M, EN>>>,
     sessionId?: string | null
   ): Promise<GetCommandResult<ResponseEntity<M, EN>>>;
-
   insertAndGetMulti<EN extends Key<M>>(
-    command: MultiInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    command: MultiInsertCommand<EN, PreEntity<ResponseEntity<M, EN>>>,
     sessionId?: string | null
   ): Promise<MultiValuesCommandResult<ResponseEntity<M, EN>>>;
-
   updateById<EN extends Key<M>>(
     command: IdUpdateCommand<EN>,
     sessionId?: string | null
   ): Promise<IdUpdateCommandResult>;
-
   updateMulti<EN extends Key<M>>(
     command: MultiUpdateCommand<EN>,
     sessionId?: string | null
   ): Promise<MultiUpdateCommandResult>;
-
   updateAndGet<EN extends Key<M>>(
     command: IdUpdateCommand<EN>,
     sessionId?: string | null
   ): Promise<GetCommandResult<ResponseEntity<M, EN>>>;
-
   updateAndFetch<EN extends Key<M>>(
     command: MultiUpdateCommand<EN>,
     sessionId?: string | null
   ): Promise<MultiValuesCommandResult<ResponseEntity<M, EN>>>;
-
   push<EN extends Key<M>>(
     command: PushCommand<EN>,
     sessionId?: string | null
   ): Promise<PushCommandResult<ResponseEntity<M, EN>>>;
-
   delete<EN extends Key<M>>(
     command: DeleteCommand<EN>,
     sessionId?: string | null
   ): Promise<DeleteCommandResult>;
 }
-
+export interface NormalizedEntityClient<
+  M extends GeneralReqResEntityMap = GeneralReqResEntityMap
+> {
+  find<EN extends Key<M>>(
+    query: WhereQuery<EN>,
+    sessionId?: string | null
+  ): Promise<QueryResult<ResponseEntity<M, EN>>>;
+  findOne<EN extends Key<M>>(
+    query: WhereQuery<EN>,
+    sessionId?: string | null
+  ): Promise<SingleQueryResult<ResponseEntity<M, EN>>>;
+  get<EN extends Key<M>>(
+    query: IdQuery<EN>,
+    sessionId?: string | null
+  ): Promise<SingleQueryResult<ResponseEntity<M, EN>>>;
+  getByIds<EN extends Key<M>>(
+    query: IdsQuery<EN>,
+    sessionId?: string | null
+  ): Promise<QueryResult<ResponseEntity<M, EN>>>;
+  pull<EN extends Key<M>>(
+    query: PullQuery<EN>,
+    sessionId?: string | null
+  ): Promise<PullQueryResult<ResponseEntity<M, EN>>>;
+  insertOne<EN extends Key<M>>(
+    command: SingleInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    sessionId?: string | null
+  ): Promise<SingleInsertCommandResult>;
+  insertMulti<EN extends Key<M>>(
+    command: MultiInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    sessionId?: string | null
+  ): Promise<MultiInsertCommandResult>;
+  insertAndGet<EN extends Key<M>>(
+    command: SingleInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    sessionId?: string | null
+  ): Promise<GetCommandResult<ResponseEntity<M, EN>>>;
+  insertAndGetMulti<EN extends Key<M>>(
+    command: MultiInsertCommand<EN, PreEntity<RequestEntity<M, EN>>>,
+    sessionId?: string | null
+  ): Promise<MultiValuesCommandResult<ResponseEntity<M, EN>>>;
+  updateById<EN extends Key<M>>(
+    command: IdUpdateCommand<EN>,
+    sessionId?: string | null
+  ): Promise<IdUpdateCommandResult>;
+  updateMulti<EN extends Key<M>>(
+    command: MultiUpdateCommand<EN>,
+    sessionId?: string | null
+  ): Promise<MultiUpdateCommandResult>;
+  updateAndGet<EN extends Key<M>>(
+    command: IdUpdateCommand<EN>,
+    sessionId?: string | null
+  ): Promise<GetCommandResult<ResponseEntity<M, EN>>>;
+  updateAndFetch<EN extends Key<M>>(
+    command: MultiUpdateCommand<EN>,
+    sessionId?: string | null
+  ): Promise<MultiValuesCommandResult<ResponseEntity<M, EN>>>;
+  push<EN extends Key<M>>(
+    command: PushCommand<EN>,
+    sessionId?: string | null
+  ): Promise<PushCommandResult<ResponseEntity<M, EN>>>;
+  delete<EN extends Key<M>>(
+    command: DeleteCommand<EN>,
+    sessionId?: string | null
+  ): Promise<DeleteCommandResult>;
+}
 export interface CustomClient<
   QM extends GeneralCustomMap,
   CM extends GeneralCustomMap
@@ -142,13 +193,11 @@ export interface CustomClient<
     query: CustomQuery<QN, CustomQueryParams<QM, QN>>,
     sessionId?: string | null
   ): Promise<CustomQueryResult<CustomQueryResultValue<QM, QN>>>;
-
   runCustomCommand<CN extends Key<CM>>(
     command: CustomCommand<CN, CustomCommandParams<CM, CN>>,
     sessionId?: string | null
   ): Promise<CustomCommandResult<CustomCommandResultValue<CM, CN>>>;
 }
-
 export interface AuthClient<
   M extends GeneralReqResEntityMap,
   AM extends GeneralAuthCommandMap
@@ -159,22 +208,18 @@ export interface AuthClient<
   ): Promise<
     LoginCommandResult<EN, ResponseAuthUser<AM, EN, M>, AuthSessions<AM, EN>>
   >;
-
   logout<EN extends Key<AM>>(
     command: LogoutCommand<EN>,
     sessionId?: string | null
   ): Promise<LogoutCommandResult>;
-
   createSessionClient(): SessionClient<AM>;
 }
-
 export type RestApiClient<TM extends GeneralTypeMap> = EntityClient<
   ReqResEntityMapOf<TM>
 > &
   CustomClient<CustomQueryMapOf<TM>, CustomCommandMapOf<TM>> &
   AuthClient<ReqResEntityMapOf<TM>, AuthCommandMapOf<TM>> &
   RestApiHandler<TM>;
-
 export type SessionClient<
   AM extends GeneralAuthCommandMap = GeneralAuthCommandMap
 > = KvsClient<AllSessions<AM>>;


### PR DESCRIPTION
Separated EntityClient into RawEntityClient and NormalizedEntityClient.
RawEntityClient is meant for server use, and NormalizedEntityClient is meant for client use.