### PR TITLE
[chore] Add ci check for typescript and master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
           key: v{{ .Environment.CIRCLECI_CACHE_VERSION }}-dependencies-{{ .Branch }}-{{ checksum "deps.txt" }}
       - run: yarn bootstrap
       - run: yarn build
+      - run: yarn type-check
       - run: yarn ci-test
   deploy:
     executor:
@@ -75,4 +76,4 @@ workflows:
           filters:
             branches:
               only:
-                - /^(release)\/.*/
+                - /^(master|release|typescript)\/.*/


### PR DESCRIPTION
Made the following changes: 
  - Added ci check for master and typescript branch
  - Add script to run `yarn type-check` on ci