### PR TITLE
chore: fix circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,4 +76,4 @@ workflows:
           filters:
             branches:
               only:
-                - /^(master|release|typescript)\/.*/
+                - /^(release)\/.*/


### PR DESCRIPTION
Sorry, the previous circleci config was made by mistake. 
The deploy part of ci should only be run by release branch