### PR TITLE
Fix/prevent return password

### DIFF
--- a/modules/standards/src/remove-password-from-response-data.ts
+++ b/modules/standards/src/remove-password-from-response-data.ts
@@ -6,7 +6,8 @@ import {
   UserEntityResponseData,
   ProEntity,
   GeneralReqResEntityMap,
-  Key
+  Key,
+  Entity
 } from "@phenyl/interfaces";
 
 export function removePasswordFromResponseData<
@@ -26,4 +27,13 @@ export function removePasswordFromResponseData<
       return res;
     }
   ) as UserEntityResponseData<EN, Ereqres["response"], C>;
+}
+
+export function removePasswordFromResponseEntity(
+  entity: Entity,
+  passwordPropName: string
+): Entity {
+  if (!hasOwnNestedProperty(entity, passwordPropName)) return entity;
+  const res = update(entity, { $unset: { [passwordPropName]: "" } });
+  return res as Entity;
 }

--- a/modules/standards/src/standard-user-definition.ts
+++ b/modules/standards/src/standard-user-definition.ts
@@ -3,7 +3,10 @@ import { createServerError } from "@phenyl/utils";
 
 import { StandardEntityDefinition } from "./standard-entity-definition";
 import { encryptPasswordInRequestData } from "./encrypt-password-in-request-data";
-import { removePasswordFromResponseData } from "./remove-password-from-response-data";
+import {
+  removePasswordFromResponseData,
+  removePasswordFromResponseEntity
+} from "./remove-password-from-response-data";
 
 import {
   GeneralReqResEntityMap,
@@ -69,7 +72,10 @@ export class StandardUserDefinition<
           [passwordPropName]: this.encrypt(password)
         }
       });
-      const user = result.entity;
+      const user = removePasswordFromResponseEntity(
+        result.entity,
+        passwordPropName
+      );
       const expiredAt = new Date(Date.now() + ttl * 1000).toISOString();
       const preSession = { expiredAt, entityName, userId: user.id };
       return { preSession, user, versionId: result.versionId };

--- a/modules/standards/test/remove-password-from-response-entity.ts
+++ b/modules/standards/test/remove-password-from-response-entity.ts
@@ -1,0 +1,26 @@
+import { it, describe } from "mocha";
+import assert from "assert";
+import { removePasswordFromResponseEntity } from "../src/remove-password-from-response-data";
+
+describe("removePasswordFromResponseEntity", () => {
+  it("should be removed passwordPropName", () => {
+    const entity = {
+      password: "hogehoge",
+      name: "Foo Bar",
+      id: "foobar"
+    };
+
+    const result = removePasswordFromResponseEntity(entity, "password");
+    assert.deepStrictEqual(result, { name: "Foo Bar", id: "foobar" });
+  });
+
+  it("should be no change when entity doesn't have passwordPropName", () => {
+    const entity = {
+      name: "Foo Bar",
+      id: "foobar"
+    };
+
+    const result = removePasswordFromResponseEntity(entity, "password");
+    assert.deepStrictEqual(result, { name: "Foo Bar", id: "foobar" });
+  });
+});

--- a/modules/standards/test/standard-definition-authentication.test.ts
+++ b/modules/standards/test/standard-definition-authentication.test.ts
@@ -112,22 +112,22 @@ after(() => {
   server.close();
 });
 
-describe("Phenyl Standards with Authentication", async () => {
+describe("Phenyl Standards with Authentication", () => {
   const client: PhenylHttpClient<MyTypeMap> = new PhenylHttpClient({
     url: "http://localhost:8080"
   });
 
-  // TODO: need refinement. Should preSession be created by others?
-  const preSession = await sessionClient.create({
-    entityName: "patient",
-    expiredAt: "",
-    userId: "shinout@example.com",
-    externalId: "",
-    ttl: 12345
-  });
-
   let insertedEntity: PatientResponse;
   it(" should be inserted first user", async () => {
+    // TODO: need refinement. Should preSession be created by others?
+    const preSession = await sessionClient.create({
+      entityName: "patient",
+      expiredAt: "",
+      userId: "shinout@example.com",
+      externalId: "",
+      ttl: 12345
+    });
+
     const inserted = await client.insertAndGet(
       {
         entityName: "patient",

--- a/modules/standards/test/standard-definition-authentication.test.ts
+++ b/modules/standards/test/standard-definition-authentication.test.ts
@@ -166,12 +166,11 @@ describe("Phenyl Standards with Authentication", async () => {
     }
     loggedInUser = loginCommandResult.user as PatientResponse;
     loggedInSession = loginCommandResult.session as Session;
-    assert.strictEqual(loggedInUser && loggedInUser.name, "Shin Suzuki");
-    assert.strictEqual(
-      loggedInUser && loggedInUser.email,
-      "shinout@example.com"
-    );
-    assert.strictEqual(loggedInUser && loggedInUser.id, insertedEntity.id);
+    assert.deepStrictEqual(loggedInUser, {
+      name: "Shin Suzuki",
+      email: "shinout@example.com",
+      id: insertedEntity.id
+    });
   });
 
   it("can updateAndGet by loggedInSession", async () => {


### PR DESCRIPTION
## Overview
StandardsUserDefinition's authentication returns hashed password when client run login command.
It's very dangerous ☠️ , so remove password property.