### PR TITLE
Revert separation of modules in interfaces

### DIFF
--- a/modules/interfaces/package.json
+++ b/modules/interfaces/package.json
@@ -10,14 +10,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
-    "clean": "rm -rf lib",
+    "build": "upbin tsc --declaration",
+    "clean": "upbin rimraf $(cat ../../.temporary-files)",
     "lint": "upbin eslint 'src/**/*.ts' 'type-test/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
     "watch": "upbin tsc --declaration --watch"

--- a/modules/interfaces/tsconfig.json
+++ b/modules/interfaces/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This reverts commit bdfb775c3d4f40b6e9fd17f551db412b9fa93eab.

interface only contains type declarations, so it does not need to be compiled into es5.

Having an empty `.js` file build in `es5` breaks build on publish, so I am reverting the separation.