### PR TITLE
Revert separating of modules

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
     }
   },
   "npmClient": "yarn",
-  "version": "1.0.0-alpha.13"
+  "version": "1.0.0-alpha.14"
 }

--- a/modules/api-explorer-client/package.json
+++ b/modules/api-explorer-client/package.json
@@ -55,5 +55,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/api-explorer-client/package.json
+++ b/modules/api-explorer-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/api-explorer-client",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "Client application of phenyl-api-explorer",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -34,9 +34,9 @@
     ]
   },
   "devDependencies": {
-    "@phenyl/http-client": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/http-client": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "@types/node": "12.0.0",
     "@types/react": "16.8.17",
     "@types/react-dom": "16.8.4",

--- a/modules/api-explorer/package.json
+++ b/modules/api-explorer/package.json
@@ -14,14 +14,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/PhenylApiExplorer.js",
-  "types": "lib/esm/PhenylApiExplorer.d.ts",
-  "module": "lib/esm/PhenylApiExplorer.js",
+  "main": "lib/PhenylApiExplorer.js",
+  "types": "lib/PhenylApiExplorer.d.ts",
   "scripts": {
     "clean": "rm -rf lib",
-    "build": "upbin npm-run-all clean build:*",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
+    "build": "upbin tsc --declaration",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "start": "nodemon --exec upbin ts-node examples/index.ts --watch src --watch examples --extensions '.ts'",
     "test": "echo no test specified in phenyl-api-explorer",
@@ -46,5 +43,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/api-explorer/package.json
+++ b/modules/api-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/api-explorer",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "Automatically renders API explorer pages like swagger",
   "repository": "https://github.com/phenyl-js/phenyl/tree/master/modules/phenyl-api-explorer",
   "license": "Apache-2.0",
@@ -25,18 +25,18 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/api-explorer-client": "^1.0.0-alpha.13",
+    "@phenyl/api-explorer-client": "^1.0.0-alpha.14",
     "ejs": "^2.6.1",
     "upbin": "^0.9.0"
   },
   "devDependencies": {
-    "@phenyl/http-client": "^1.0.0-alpha.13",
-    "@phenyl/http-server": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/lambda-adapter": "^1.0.0-alpha.13",
-    "@phenyl/memory-db": "^1.0.0-alpha.13",
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
-    "@phenyl/standards": "^1.0.0-alpha.13",
+    "@phenyl/http-client": "^1.0.0-alpha.14",
+    "@phenyl/http-server": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/lambda-adapter": "^1.0.0-alpha.14",
+    "@phenyl/memory-db": "^1.0.0-alpha.14",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
+    "@phenyl/standards": "^1.0.0-alpha.14",
     "@types/ejs": "^2.6.2",
     "nodemon": "^1.18.3",
     "power-crypt": "^0.2.2"

--- a/modules/api-explorer/tsconfig.json
+++ b/modules/api-explorer/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/central-state/package.json
+++ b/modules/central-state/package.json
@@ -10,14 +10,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "types": "lib/esm/index.d.ts",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "module": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf lib",
-    "build": "upbin npm-run-all clean build:*",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
+    "build": "upbin tsc --declaration",
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
@@ -30,5 +27,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/central-state/package.json
+++ b/modules/central-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/central-state",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache License 2.0",
@@ -18,8 +18,8 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "sp2": "^1.4.1"
   },
   "devDependencies": {

--- a/modules/central-state/tsconfig.json
+++ b/modules/central-state/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/express",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "Express middleware to use Phenyl in it.",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -19,23 +19,22 @@
   "scripts": {
     "build": "upbin tsc --declaration",
     "ci-test": "yarn test",
-    
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/http-rules": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/http-rules": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "express": "^4.16.4",
     "raw-body": "^2.3.2"
   },
   "devDependencies": {
-    "@phenyl/http-client": "^1.0.0-alpha.13",
-    "@phenyl/memory-db": "^1.0.0-alpha.13",
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
+    "@phenyl/http-client": "^1.0.0-alpha.14",
+    "@phenyl/memory-db": "^1.0.0-alpha.14",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
     "upbin": "^0.8.1"
   },
   "publishConfig": {

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -13,15 +13,13 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "types": "lib/esm/index.d.ts",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "module": "lib/index.js",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "yarn test",
-    "clean": "rm -rf lib",
+    
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
@@ -42,5 +40,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/express/tsconfig.json
+++ b/modules/express/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/http-client/package.json
+++ b/modules/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/http-client",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -23,15 +23,15 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/http-rules": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/http-rules": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "cross-fetch": "^3.0.2"
   },
   "devDependencies": {
-    "@phenyl/http-server": "^1.0.0-alpha.13",
-    "@phenyl/memory-db": "^1.0.0-alpha.13",
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
+    "@phenyl/http-server": "^1.0.0-alpha.14",
+    "@phenyl/memory-db": "^1.0.0-alpha.14",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
     "power-assert": "^1.4.4",
     "upbin": "^0.9.0"
   },

--- a/modules/http-client/package.json
+++ b/modules/http-client/package.json
@@ -37,5 +37,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/http-rules/package.json
+++ b/modules/http-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/http-rules",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -22,8 +22,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13"
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14"
   },
   "devDependencies": {
     "upbin": "^0.9.0"

--- a/modules/http-rules/package.json
+++ b/modules/http-rules/package.json
@@ -10,14 +10,12 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "types": "lib/esm/index.d.ts",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "module": "lib/index.js",
   "scripts": {
     "clean": "rm -rf lib",
-    "build": "upbin npm-run-all clean build:*",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
+    "build": "upbin tsc --declaration",
     "ci-test": "upbin nyc mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
@@ -32,5 +30,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/http-rules/tsconfig.json
+++ b/modules/http-rules/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/http-server/package.json
+++ b/modules/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/http-server",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -24,8 +24,8 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/http-rules": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13"
+    "@phenyl/http-rules": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14"
   },
   "devDependencies": {
     "@babel/register": "^7.4.0",

--- a/modules/http-server/package.json
+++ b/modules/http-server/package.json
@@ -14,13 +14,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit"
@@ -35,5 +33,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/http-server/tsconfig.json
+++ b/modules/http-server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/interfaces/package.json
+++ b/modules/interfaces/package.json
@@ -27,5 +27,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/interfaces/package.json
+++ b/modules/interfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/interfaces",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",

--- a/modules/lambda-adapter/package.json
+++ b/modules/lambda-adapter/package.json
@@ -13,13 +13,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "echo no test",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
@@ -35,5 +33,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/lambda-adapter/package.json
+++ b/modules/lambda-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/lambda-adapter",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "Adapter for AWS lambda",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/http-rules": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13"
+    "@phenyl/http-rules": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14"
   },
   "devDependencies": {
     "upbin": "^0.9.0"

--- a/modules/lambda-adapter/tsconfig.json
+++ b/modules/lambda-adapter/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/memory-db/package.json
+++ b/modules/memory-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/memory-db",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -21,14 +21,14 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/central-state": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/state": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/central-state": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/state": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "sp2": "^1.4.1"
   },
   "devDependencies": {
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
     "upbin": "^0.9.0"
   },
   "publishConfig": {

--- a/modules/memory-db/package.json
+++ b/modules/memory-db/package.json
@@ -10,13 +10,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "yarn test",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
@@ -35,5 +33,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/memory-db/tsconfig.json
+++ b/modules/memory-db/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/mongodb/package.json
+++ b/modules/mongodb/package.json
@@ -13,13 +13,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "upbin nyc npm test --color always",
     "clean": "rm -rf lib",
     "pretest": "test/scripts/init-mongodb.sh",
@@ -43,5 +41,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/mongodb/package.json
+++ b/modules/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/mongodb",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -26,9 +26,9 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/central-state": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/central-state": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "@types/mongodb": "^3.1.26",
     "bson": "^4.0.0",
     "es6-promisify": "^5.0.0",
@@ -36,7 +36,7 @@
     "sp2": "~1.4.0"
   },
   "devDependencies": {
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
     "upbin": "^0.9.0"
   },
   "publishConfig": {

--- a/modules/mongodb/tsconfig.json
+++ b/modules/mongodb/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/redux/package.json
+++ b/modules/redux/package.json
@@ -14,13 +14,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "yarn test",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
@@ -43,5 +41,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/redux/package.json
+++ b/modules/redux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/redux",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "https://github.com/phenyl-js/phenyl/tree/master/modules/phenyl-redux",
   "license": "Apache-2.0",
@@ -25,17 +25,17 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "fast-deep-equal": "^1.0.0",
     "sp2": "~1.4.1"
   },
   "devDependencies": {
-    "@phenyl/http-client": "^1.0.0-alpha.13",
-    "@phenyl/http-server": "^1.0.0-alpha.13",
-    "@phenyl/memory-db": "^1.0.0-alpha.13",
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
-    "@phenyl/standards": "^1.0.0-alpha.13",
+    "@phenyl/http-client": "^1.0.0-alpha.14",
+    "@phenyl/http-server": "^1.0.0-alpha.14",
+    "@phenyl/memory-db": "^1.0.0-alpha.14",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
+    "@phenyl/standards": "^1.0.0-alpha.14",
     "redux": "^4.0.1",
     "upbin": "^0.9.0"
   },

--- a/modules/redux/tsconfig.json
+++ b/modules/redux/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/rest-api",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -20,9 +20,9 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/central-state": "^1.0.0-alpha.13",
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13"
+    "@phenyl/central-state": "^1.0.0-alpha.14",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14"
   },
   "devDependencies": {
     "upbin": "^0.9.0"

--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -29,5 +29,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/standards/package.json
+++ b/modules/standards/package.json
@@ -13,13 +13,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin mocha --require ts-node/register 'test/**/*.ts' --color always",
@@ -40,5 +38,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/standards/package.json
+++ b/modules/standards/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/standards",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -24,16 +24,16 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "power-crypt": "~0.2.2",
     "sp2": "~1.4.1"
   },
   "devDependencies": {
-    "@phenyl/http-client": "^1.0.0-alpha.13",
-    "@phenyl/http-server": "^1.0.0-alpha.13",
-    "@phenyl/memory-db": "^1.0.0-alpha.13",
-    "@phenyl/rest-api": "^1.0.0-alpha.13",
+    "@phenyl/http-client": "^1.0.0-alpha.14",
+    "@phenyl/http-server": "^1.0.0-alpha.14",
+    "@phenyl/memory-db": "^1.0.0-alpha.14",
+    "@phenyl/rest-api": "^1.0.0-alpha.14",
     "upbin": "^0.9.0"
   },
   "publishConfig": {

--- a/modules/standards/tsconfig.json
+++ b/modules/standards/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/state/package.json
+++ b/modules/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/state",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -21,7 +21,7 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
     "sp2": "^1.4.1"
   },
   "devDependencies": {

--- a/modules/state/package.json
+++ b/modules/state/package.json
@@ -10,13 +10,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
-  "types": "lib/esm/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "ci-test": "yarn test",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register test/*.ts --color always",
@@ -31,5 +29,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/state/tsconfig.json
+++ b/modules/state/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/utils/package.json
+++ b/modules/utils/package.json
@@ -32,5 +32,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/utils/package.json
+++ b/modules/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/utils",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -24,7 +24,7 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
     "sp2": "~1.4.0"
   },
   "devDependencies": {

--- a/modules/websocket-client/package.json
+++ b/modules/websocket-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/websocket-client",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "phenyl-js/phenyl",
   "license": "Apache-2.0",
@@ -24,11 +24,11 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "ws": "^3.3.1"
   },
   "devDependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
     "@types/ws": "^6.0.1",
     "babel-register": "^6.24.1",
     "upbin": "^0.9.0"

--- a/modules/websocket-client/package.json
+++ b/modules/websocket-client/package.json
@@ -10,16 +10,14 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
   "browser": {
     "./src/websocket.js": "./src/websocket.browser.js"
   },
   "types": "lib/esm/index.d.ts",
   "scripts": {
-    "build": "upbin npm-run-all clean build:*",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
+    "build": "upbin tsc --declaration",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
@@ -37,5 +35,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/websocket-client/tsconfig.json
+++ b/modules/websocket-client/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }

--- a/modules/websocket-server/package.json
+++ b/modules/websocket-server/package.json
@@ -14,14 +14,11 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "lib/cjs/index.js",
-  "types": "lib/esm/index.d.ts",
-  "module": "lib/esm/index.js",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "module": "lib/index.js",
   "scripts": {
-    "clean": "rm -rf lib",
-    "build": "upbin npm-run-all clean build:*",
-    "build:esm": "upbin tsc --target es6 --outDir lib/esm --module es6",
-    "build:cjs": "upbin tsc --target es5 --outDir lib/cjs --module commonjs",
+    "build": "upbin tsc --declaration",
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
@@ -37,5 +34,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "gitHead": "fc31a5e585f024ab28f8b1bcb46768fe684fd582"
 }

--- a/modules/websocket-server/package.json
+++ b/modules/websocket-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phenyl/websocket-server",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "description": "",
   "repository": "https://github.com/phenyl-js/phenyl/tree/master/modules/phenyl-websocket-server",
   "license": "Apache-2.0",
@@ -22,11 +22,11 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@phenyl/utils": "^1.0.0-alpha.13",
+    "@phenyl/utils": "^1.0.0-alpha.14",
     "ws": "^3.3.1"
   },
   "devDependencies": {
-    "@phenyl/interfaces": "^1.0.0-alpha.13",
+    "@phenyl/interfaces": "^1.0.0-alpha.14",
     "@types/ws": "^6.0.1",
     "babel-register": "^6.24.1",
     "mocha": "^5.0.5",

--- a/modules/websocket-server/tsconfig.json
+++ b/modules/websocket-server/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "declaration": true
+    "outDir": "lib"
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
temporarily building packages only in es5 without separating them into cjs and modules