### PR TITLE
Fix bug: Execute login without wrap execution

### DIFF
--- a/modules/interfaces/src/custom-command-definition.ts
+++ b/modules/interfaces/src/custom-command-definition.ts
@@ -1,9 +1,10 @@
 import { CustomCommand } from "./command";
 import { CustomCommandResult } from "./command-result";
 import { GeneralCustomCommandRequestData } from "./request-data";
+import { GeneralDefinition } from "./entity-definition";
 import { Session } from "./session";
 
-export interface CustomCommandDefinition {
+export interface CustomCommandDefinition extends GeneralDefinition {
   authorize?: (
     reqData: GeneralCustomCommandRequestData,
     session?: Session

--- a/modules/interfaces/src/custom-query-definition.ts
+++ b/modules/interfaces/src/custom-query-definition.ts
@@ -1,9 +1,10 @@
 import { CustomQuery } from "./query";
 import { CustomQueryResult } from "./query-result";
 import { GeneralCustomQueryRequestData } from "./request-data";
+import { GeneralDefinition } from "./entity-definition";
 import { Session } from "./session";
 
-export interface CustomQueryDefinition {
+export interface CustomQueryDefinition extends GeneralDefinition {
   authorize?: (
     reqData: GeneralCustomQueryRequestData,
     session?: Session

--- a/modules/interfaces/src/entity-definition.ts
+++ b/modules/interfaces/src/entity-definition.ts
@@ -6,7 +6,30 @@ import {
 
 import { Session } from "./session";
 
-export interface EntityDefinition {
+export interface GeneralDefinition {
+  authorize?: (
+    reqData: GeneralRequestData,
+    session?: Session
+  ) => Promise<boolean>;
+
+  normalize?: (
+    reqData: GeneralRequestData,
+    session?: Session
+  ) => Promise<GeneralRequestData>;
+
+  validate?: (reqData: GeneralRequestData, session?: Session) => Promise<void>;
+
+  wrapExecution?: (
+    reqData: GeneralRequestData,
+    session: Session | undefined,
+    executeFn: (
+      reqData: GeneralRequestData,
+      session?: Session
+    ) => Promise<GeneralResponseData>
+  ) => Promise<GeneralResponseData>;
+}
+
+export interface EntityDefinition extends GeneralDefinition {
   authorize?: (
     reqData: GeneralEntityRequestData,
     session?: Session
@@ -20,11 +43,11 @@ export interface EntityDefinition {
   validate?: (reqData: GeneralRequestData, session?: Session) => Promise<void>;
 
   wrapExecution?: (
-    reqData: GeneralRequestData,
-    session: Session,
+    reqData: GeneralEntityRequestData,
+    session: Session | undefined,
     executeFn: (
-      reqData: GeneralRequestData,
+      reqData: GeneralEntityRequestData,
       session?: Session
-    ) => Promise<GeneralResponseData>
+    ) => Promise<GeneralEntityResponseData>
   ) => Promise<GeneralEntityResponseData>;
 }

--- a/modules/interfaces/src/query-result.ts
+++ b/modules/interfaces/src/query-result.ts
@@ -5,17 +5,17 @@ export type CustomQueryResult<QR extends Object = Object> = {
   result: QR;
 };
 
-export type QueryResult<E extends Entity> = {
+export type QueryResult<E extends Entity = Entity> = {
   entities: E[];
   versionsById: { [entityId: string]: string | null };
 };
 
-export type SingleQueryResult<E extends Entity> = {
+export type SingleQueryResult<E extends Entity = Entity> = {
   entity: E;
   versionId: string | null;
 };
 
-export type PullQueryResult<E extends Entity> =
+export type PullQueryResult<E extends Entity = Entity> =
   | {
       pulled: 1;
       operations: GeneralUpdateOperation[];

--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -1,10 +1,9 @@
-import { UserEntityRequestData } from "./request-data";
-
 import { Entity } from "./entity";
+import { GeneralDefinition } from "./entity-definition";
 import { LoginCommand } from "./command";
 import { PreSession } from "./session";
 import { Session } from "./session";
-
+import { UserEntityRequestData } from "./request-data";
 import { UserEntityResponseData } from "./response-data";
 
 export type AuthenticationResult<
@@ -17,14 +16,12 @@ export type AuthenticationResult<
   versionId: string | null;
 };
 
-export interface AuthDefinition {
+export interface UserDefinition extends GeneralDefinition {
   authenticate(
     loginCommand: LoginCommand,
     session?: Session
   ): Promise<AuthenticationResult>;
-}
 
-export interface UserDefinition extends AuthDefinition {
   authorize?: (
     reqData: UserEntityRequestData,
     session?: Session
@@ -49,3 +46,5 @@ export interface UserDefinition extends AuthDefinition {
     ) => Promise<UserEntityResponseData>
   ) => Promise<UserEntityResponseData>;
 }
+
+export type AuthDefinition = Pick<UserDefinition, "authenticate">;

--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -16,6 +16,7 @@
     "build": "upbin tsc --declaration",
     "clean": "upbin rimraf $(cat ../../.temporary-files)",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
+    "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
     "watch": "upbin tsc --declaration --watch"
   },

--- a/modules/rest-api/src/definition-executor.ts
+++ b/modules/rest-api/src/definition-executor.ts
@@ -80,6 +80,7 @@ export abstract class DefinitionExecutor {
   ): Promise<GeneralResponseData>;
 }
 
+/* eslint-disable-next-line */
 export class EntityDefinitionExecutor extends DefinitionExecutor {
   definition: EntityDefinition;
   client: EntityClient;
@@ -191,6 +192,7 @@ async function executeEntityRequestData(
   }
 }
 
+/* eslint-disable-next-line */
 export class UserDefinitionExecutor extends DefinitionExecutor {
   definition: UserDefinition;
   client: EntityClient;
@@ -254,6 +256,7 @@ export class UserDefinitionExecutor extends DefinitionExecutor {
   }
 }
 
+/* eslint-disable-next-line */
 export class CustomQueryDefinitionExecutor extends DefinitionExecutor {
   definition: CustomQueryDefinition;
   client: EntityClient;
@@ -275,6 +278,7 @@ export class CustomQueryDefinitionExecutor extends DefinitionExecutor {
   }
 }
 
+/* eslint-disable-next-line */
 export class CustomCommandDefinitionExecutor extends DefinitionExecutor {
   definition: CustomCommandDefinition;
   client: EntityClient;

--- a/modules/rest-api/src/definition-executor.ts
+++ b/modules/rest-api/src/definition-executor.ts
@@ -8,85 +8,93 @@ import {
   GeneralCustomCommandResponseData,
   GeneralCustomQueryRequestData,
   GeneralCustomQueryResponseData,
+  GeneralDefinition,
   GeneralEntityRequestData,
   GeneralEntityResponseData,
   GeneralRequestData,
   GeneralResponseData,
   GeneralUserEntityRequestData,
-  UserEntityResponseData,
   LoginCommand,
   LoginResponseData,
   LogoutCommand,
   LogoutResponseData,
   Session,
   SessionClient,
-  UserDefinition
+  UserDefinition,
+  UserEntityResponseData
 } from "@phenyl/interfaces";
 
-import { createServerError } from "@phenyl/utils";
 import { ErrorResponseData } from "@phenyl/interfaces";
+import { createServerError } from "@phenyl/utils";
 
-export class EntityDefinitionExecutor implements DefinitionExecutor {
+export abstract class DefinitionExecutor {
+  definition: GeneralDefinition;
+
+  constructor(definition: GeneralDefinition) {
+    this.definition = definition;
+  }
+
+  async authorize(
+    reqData: GeneralRequestData,
+    session?: Session
+  ): Promise<boolean> {
+    return this.definition.authorize
+      ? this.definition.authorize(reqData, session)
+      : true;
+  }
+
+  async normalize(
+    reqData: GeneralRequestData,
+    session?: Session
+  ): Promise<GeneralRequestData> {
+    return this.definition.normalize
+      ? this.definition.normalize(reqData, session)
+      : reqData;
+  }
+
+  async validate(
+    reqData: GeneralRequestData,
+    session?: Session
+  ): Promise<void> {
+    if (this.definition.validate) {
+      await this.definition.validate(reqData, session);
+    }
+  }
+
+  async execute(
+    reqData: GeneralRequestData,
+    session?: Session
+  ): Promise<GeneralResponseData> {
+    return this.definition.wrapExecution
+      ? this.definition.wrapExecution(
+          reqData,
+          session,
+          this.executeOwn.bind(this)
+        )
+      : this.executeOwn(reqData, session);
+  }
+
+  abstract executeOwn(
+    reqData: GeneralRequestData,
+    session?: Session
+  ): Promise<GeneralResponseData>;
+}
+
+export class EntityDefinitionExecutor extends DefinitionExecutor {
   definition: EntityDefinition;
   client: EntityClient;
 
   constructor(definition: EntityDefinition, client: EntityClient) {
+    super(definition);
     this.definition = definition;
     this.client = client;
-
-    if (this.definition.authorize == null) {
-      this.authorize = () => Promise.resolve(true);
-    }
-    if (this.definition.normalize == null) {
-      this.normalize = val => Promise.resolve(val);
-    }
-    if (this.definition.validate == null) {
-      this.validate = () => Promise.resolve();
-    }
-    if (this.definition.wrapExecution == null) {
-      this.execute = executeEntityRequestData.bind(this, this.client);
-    }
   }
 
-  async authorize(
-    reqData: GeneralEntityRequestData,
-    session?: Session
-  ): Promise<boolean> {
-    return this.definition.authorize!(reqData, session);
-  }
-
-  async validate(
-    reqData: GeneralEntityRequestData,
-    session?: Session
-  ): Promise<void> {
-    return this.definition.validate!(reqData, session);
-  }
-
-  async normalize(
-    reqData: GeneralEntityRequestData,
-    session?: Session
-  ): Promise<GeneralEntityRequestData> {
-    return this.definition.normalize!(reqData, session);
-  }
-
-  async execute(
+  async executeOwn(
     reqData: GeneralEntityRequestData,
     session?: Session
   ): Promise<GeneralEntityResponseData | ErrorResponseData> {
-    if (session === undefined) {
-      const errorResult: ErrorResponseData = {
-        type: "error",
-        payload: createServerError(
-          `Execute method ${reqData.method} must needs session`
-        )
-      };
-      return errorResult;
-    }
-    return this.definition.wrapExecution!(
-      reqData,
-      session,
-      executeEntityRequestData.bind(this, this.client)
-    );
+    return executeEntityRequestData(this.client, reqData, session);
   }
 }
 
@@ -183,7 +191,7 @@ async function executeEntityRequestData(
   }
 }
 
-export class UserDefinitionExecutor implements DefinitionExecutor {
+export class UserDefinitionExecutor extends DefinitionExecutor {
   definition: UserDefinition;
   client: EntityClient;
   sessionClient: SessionClient;
@@ -193,50 +201,16 @@ export class UserDefinitionExecutor implements DefinitionExecutor {
     client: EntityClient,
     sessionClient: SessionClient
   ) {
+    super(definition);
     this.definition = definition;
     this.client = client;
     this.sessionClient = sessionClient;
-
-    if (this.definition.authorize == null) {
-      this.authorize = () => Promise.resolve(true);
-    }
-    if (this.definition.normalize == null) {
-      this.normalize = val => Promise.resolve(val);
-    }
-    if (this.definition.validate == null) {
-      this.validate = () => Promise.resolve();
-    }
-    if (this.definition.wrapExecution == null) {
-      this.execute = executeEntityRequestData.bind(this, this.client);
-    }
   }
 
-  async authorize(
+  async executeOwn(
     reqData: GeneralUserEntityRequestData,
     session?: Session
-  ): Promise<boolean> {
-    return this.definition.authorize!(reqData, session);
-  }
-
-  async validate(
-    reqData: GeneralUserEntityRequestData,
-    session?: Session
-  ): Promise<void> {
-    return this.definition.validate!(reqData, session);
-  }
-
-  async normalize(
-    reqData: GeneralUserEntityRequestData,
-    session?: Session
-  ): Promise<GeneralUserEntityRequestData> {
-    return this.definition.normalize!(reqData, session);
-  }
-
-  async execute(
-    reqData: GeneralUserEntityRequestData,
-    session?: Session
-  ): Promise<UserEntityResponseData | ErrorResponseData> {
-    // TODO: use HandlerRequest Type instead of Promise
+  ): Promise<UserEntityResponseData> {
     if (reqData.method == "logout") {
       return this.logout(reqData.payload);
     }
@@ -244,21 +218,7 @@ export class UserDefinitionExecutor implements DefinitionExecutor {
       return this.login(reqData.payload, session);
     }
 
-    if (session === undefined) {
-      const errorResult: ErrorResponseData = {
-        type: "error",
-        payload: createServerError(
-          `Method ${reqData.method} requires an active session`,
-          "Unauthorized"
-        )
-      };
-      return errorResult;
-    }
-    return this.definition.wrapExecution!(
-      reqData,
-      session,
-      executeEntityRequestData.bind(this, this.client)
-    );
+    return executeEntityRequestData(this.client, reqData, session);
   }
 
   private async login(
@@ -294,47 +254,17 @@ export class UserDefinitionExecutor implements DefinitionExecutor {
   }
 }
 
-export class CustomQueryDefinitionExecutor implements DefinitionExecutor {
+export class CustomQueryDefinitionExecutor extends DefinitionExecutor {
   definition: CustomQueryDefinition;
   client: EntityClient;
 
   constructor(definition: CustomQueryDefinition, client: EntityClient) {
+    super(definition);
     this.definition = definition;
     this.client = client;
-
-    if (this.definition.authorize == null) {
-      this.authorize = () => Promise.resolve(true);
-    }
-    if (this.definition.normalize == null) {
-      this.normalize = val => Promise.resolve(val);
-    }
-    if (this.definition.validate == null) {
-      this.validate = () => Promise.resolve();
-    }
   }
 
-  async authorize(
-    reqData: GeneralCustomQueryRequestData,
-    session?: Session
-  ): Promise<boolean> {
-    return this.definition.authorize!(reqData, session);
-  }
-
-  async validate(
-    reqData: GeneralCustomQueryRequestData,
-    session?: Session
-  ): Promise<void> {
-    return this.definition.validate!(reqData, session);
-  }
-
-  async normalize(
-    reqData: GeneralCustomQueryRequestData,
-    session?: Session
-  ): Promise<GeneralCustomQueryRequestData> {
-    return this.definition.normalize!(reqData, session);
-  }
-
-  async execute(
+  async executeOwn(
     reqData: GeneralCustomQueryRequestData,
     session?: Session
   ): Promise<GeneralCustomQueryResponseData | ErrorResponseData> {
@@ -345,47 +275,17 @@ export class CustomQueryDefinitionExecutor implements DefinitionExecutor {
   }
 }
 
-export class CustomCommandDefinitionExecutor implements DefinitionExecutor {
+export class CustomCommandDefinitionExecutor extends DefinitionExecutor {
   definition: CustomCommandDefinition;
   client: EntityClient;
 
   constructor(definition: CustomCommandDefinition, client: EntityClient) {
+    super(definition);
     this.definition = definition;
     this.client = client;
-
-    if (this.definition.authorize == null) {
-      this.authorize = () => Promise.resolve(true);
-    }
-    if (this.definition.normalize == null) {
-      this.normalize = val => Promise.resolve(val);
-    }
-    if (this.definition.validate == null) {
-      this.validate = () => Promise.resolve();
-    }
   }
 
-  async authorize(
-    reqData: GeneralCustomCommandRequestData,
-    session?: Session
-  ): Promise<boolean> {
-    return this.definition.authorize!(reqData, session);
-  }
-
-  async validate(
-    reqData: GeneralCustomCommandRequestData,
-    session?: Session
-  ): Promise<void> {
-    return this.definition.validate!(reqData, session);
-  }
-
-  async normalize(
-    reqData: GeneralCustomCommandRequestData,
-    session?: Session
-  ): Promise<GeneralCustomCommandRequestData> {
-    return this.definition.normalize!(reqData, session);
-  }
-
-  async execute(
+  async executeOwn(
     reqData: GeneralCustomCommandRequestData,
     session?: Session
   ): Promise<GeneralCustomCommandResponseData | ErrorResponseData> {
@@ -394,20 +294,4 @@ export class CustomCommandDefinitionExecutor implements DefinitionExecutor {
       payload: await this.definition.execute(reqData.payload, session)
     };
   }
-}
-
-export interface DefinitionExecutor {
-  authorize(reqData: GeneralRequestData, session?: Session): Promise<boolean>;
-
-  normalize(
-    reqData: GeneralRequestData,
-    session?: Session
-  ): Promise<GeneralRequestData>;
-
-  validate(reqData: GeneralRequestData, session?: Session): Promise<void>;
-
-  execute(
-    reqData: GeneralRequestData,
-    session?: Session
-  ): Promise<GeneralResponseData>;
 }

--- a/modules/rest-api/test/defiintion-executor.test.ts
+++ b/modules/rest-api/test/defiintion-executor.test.ts
@@ -1,0 +1,492 @@
+import {
+  AuthenticationResult,
+  CustomCommandDefinition,
+  CustomQueryDefinition,
+  EntityClient,
+  EntityDefinition,
+  GeneralCustomCommandRequestData,
+  GeneralCustomQueryRequestData,
+  GeneralRequestData,
+  GeneralResponseData,
+  QueryResult,
+  UserDefinition
+} from "@phenyl/interfaces";
+/* eslint-env mocha */
+import {
+  CustomCommandDefinitionExecutor,
+  CustomQueryDefinitionExecutor,
+  EntityDefinitionExecutor,
+  UserDefinitionExecutor
+} from "../src/definition-executor";
+
+import assert from "assert";
+
+// @ts-ignore mocking EntityClient
+const clientMock: EntityClient = { find: () => queryResult };
+// @ts-ignore mocking EntityClient
+const sessionClientMock: SessionClient = {
+  get: () => null,
+  create: () => ({})
+};
+
+const findReqData: GeneralRequestData = {
+  method: "find",
+  // @ts-ignore
+  payload: { entityName: "foo", where: {} }
+};
+
+const findReqData2: GeneralRequestData = {
+  method: "find",
+  payload: { entityName: "bar", where: {} }
+};
+
+const queryResult: QueryResult = { entities: [], versionsById: {} };
+const findResData: GeneralResponseData = {
+  type: "find",
+  // @ts-ignore
+  payload: {
+    entities: [{ id: "foo", name: "bar" }],
+    versionsById: {}
+  }
+};
+
+describe("EntityDefinitionExecutor", () => {
+  describe("authorize()", () => {
+    it("should return true when a definition without authorize() method is given", async () => {
+      const executor = new EntityDefinitionExecutor(
+        {} as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(findReqData);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return the result of a given definition's authorize() method when it exists", async () => {
+      const executor = new EntityDefinitionExecutor(
+        { authorize: async () => false } as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(findReqData);
+      assert.strictEqual(result, false);
+    });
+  });
+
+  describe("validate()", () => {
+    it("should do nothing when a definition without validate() method is given", async () => {
+      const executor = new EntityDefinitionExecutor(
+        {} as EntityDefinition,
+        clientMock
+      );
+      await executor.validate(findReqData);
+      assert.ok(true);
+    });
+
+    it("should run a given definition's validate() method when it exists", async () => {
+      let counter = 0;
+      const executor = new EntityDefinitionExecutor(
+        {
+          validate: async () => {
+            counter++;
+            return;
+          }
+        } as EntityDefinition,
+        clientMock
+      );
+      await executor.validate(findReqData);
+      assert.strictEqual(counter, 1);
+    });
+  });
+
+  describe("normalize()", () => {
+    it("should return the same RequestData when a definition without normalize() method is given", async () => {
+      const executor = new EntityDefinitionExecutor(
+        {} as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(findReqData);
+      assert.strictEqual(result, findReqData);
+    });
+
+    it("should return the result of a given definition's normalize() method when it exists", async () => {
+      const executor = new EntityDefinitionExecutor(
+        { normalize: async () => findReqData2 } as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(findReqData);
+      assert.strictEqual(result, findReqData2);
+    });
+  });
+
+  describe("execute()", () => {
+    it("should run the client's method when a definition without wrapExecution() method is given", async () => {
+      const executor = new EntityDefinitionExecutor(
+        {} as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.execute(findReqData);
+      assert.deepStrictEqual(result, { type: "find", payload: queryResult });
+    });
+
+    it("should return the wrapped result of a given definition's wrapExecution() method when it exists", async () => {
+      const executor = new EntityDefinitionExecutor(
+        { wrapExecution: async () => findResData } as EntityDefinition,
+        clientMock
+      );
+      const result = await executor.execute(findReqData);
+      assert.strictEqual(result, findResData);
+    });
+  });
+});
+
+describe("UserDefinitionExecutor", () => {
+  describe("authorize()", () => {
+    it("should return true when a definition without authorize() method is given", async () => {
+      const executor = new UserDefinitionExecutor(
+        {} as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.authorize(findReqData);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return the result of a given definition's authorize() method when it exists", async () => {
+      const authenticate = async () => ({} as AuthenticationResult);
+      const executor = new UserDefinitionExecutor(
+        { authenticate, authorize: async () => false } as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.authorize(findReqData);
+      assert.strictEqual(result, false);
+    });
+  });
+
+  describe("validate()", () => {
+    it("should do nothing when a definition without validate() method is given", async () => {
+      const executor = new UserDefinitionExecutor(
+        {} as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      await executor.validate(findReqData);
+      assert.ok(true);
+    });
+
+    it("should run a given definition's validate() method when it exists", async () => {
+      let counter = 0;
+      const authenticate = async () => ({} as AuthenticationResult);
+      const executor = new UserDefinitionExecutor(
+        {
+          authenticate,
+          validate: async () => {
+            counter++;
+            return;
+          }
+        } as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      await executor.validate(findReqData);
+      assert.strictEqual(counter, 1);
+    });
+  });
+
+  describe("normalize()", () => {
+    it("should return the same RequestData when a definition without normalize() method is given", async () => {
+      const executor = new UserDefinitionExecutor(
+        {} as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.normalize(findReqData);
+      assert.strictEqual(result, findReqData);
+    });
+
+    it("should return the result of a given definition's normalize() method when it exists", async () => {
+      const authenticate = async () => ({} as AuthenticationResult);
+      const executor = new UserDefinitionExecutor(
+        { authenticate, normalize: async () => findReqData2 } as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.normalize(findReqData);
+      assert.strictEqual(result, findReqData2);
+    });
+  });
+
+  describe("execute()", () => {
+    it("should run the client's method when a definition without wrapExecution() method is given", async () => {
+      const executor = new UserDefinitionExecutor(
+        {} as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.execute(findReqData);
+      assert.deepStrictEqual(result, { type: "find", payload: queryResult });
+    });
+
+    it("should return the wrapped result of a given definition's wrapExecution() method when it exists", async () => {
+      const authenticate = async () => ({} as AuthenticationResult);
+      const executor = new UserDefinitionExecutor(
+        {
+          authenticate,
+          wrapExecution: async () => findResData
+        } as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.execute(findReqData);
+      assert.strictEqual(result, findResData);
+    });
+
+    it("should run definition's authenticate() method when LoginRequestData is given", async () => {
+      // @ts-ignore
+      const authenticate = async () =>
+        ({ versionId: "abcd" } as AuthenticationResult);
+      const executor = new UserDefinitionExecutor(
+        {
+          authenticate
+        } as UserDefinition,
+        clientMock,
+        sessionClientMock
+      );
+      const result = await executor.execute({
+        method: "login",
+        payload: { entityName: "xxx", credentials: {} }
+      });
+      // @ts-ignore
+      assert.strictEqual(result.payload.versionId, "abcd");
+    });
+  });
+});
+
+describe("CustomQueryDefinitionExecutor", () => {
+  const customQueryReqData: GeneralCustomQueryRequestData = {
+    method: "runCustomQuery",
+    payload: { name: "hogefuga", params: { foo: 345 } }
+  };
+  describe("authorize()", () => {
+    it("should return true when a definition without authorize() method is given", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(customQueryReqData);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return the result of a given definition's authorize() method when it exists", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          authorize: async () => false
+        } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(customQueryReqData);
+      assert.strictEqual(result, false);
+    });
+  });
+
+  describe("validate()", () => {
+    it("should do nothing when a definition without validate() method is given", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomQueryDefinition,
+        clientMock
+      );
+      await executor.validate(customQueryReqData);
+      assert.ok(true);
+    });
+
+    it("should run a given definition's validate() method when it exists", async () => {
+      let counter = 0;
+      const executor = new CustomQueryDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          validate: async () => {
+            counter++;
+            return;
+          }
+        } as CustomQueryDefinition,
+        clientMock
+      );
+      await executor.validate(customQueryReqData);
+      assert.strictEqual(counter, 1);
+    });
+  });
+
+  describe("normalize()", () => {
+    it("should return the same RequestData when a definition without normalize() method is given", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(customQueryReqData);
+      assert.strictEqual(result, customQueryReqData);
+    });
+
+    it("should return the result of a given definition's normalize() method when it exists", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          normalize: async () =>
+            Object.assign({}, customQueryReqData, { ex: 1 })
+        } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(customQueryReqData);
+      assert.deepStrictEqual(
+        result,
+        Object.assign({}, customQueryReqData, { ex: 1 })
+      );
+    });
+  });
+
+  describe("execute()", () => {
+    it("should return the result of exexute() when a given definition has no wrapExecution() method", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.execute(customQueryReqData);
+      assert.deepStrictEqual(result, {
+        type: "runCustomQuery",
+        payload: { result: 123 }
+      });
+    });
+
+    it("should return the wrapped result of a given definition's wrapExecution() method when it exists", async () => {
+      const executor = new CustomQueryDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          wrapExecution: async () => ({
+            type: "runCustomQuery",
+            payload: { result: 345 }
+          })
+        } as CustomQueryDefinition,
+        clientMock
+      );
+      const result = await executor.execute(customQueryReqData);
+      assert.deepStrictEqual(result, {
+        type: "runCustomQuery",
+        payload: { result: 345 }
+      });
+    });
+  });
+});
+
+describe("CustomCommandDefinitionExecutor", () => {
+  const customCommandReqData: GeneralCustomCommandRequestData = {
+    method: "runCustomCommand",
+    payload: { name: "hogefuga", params: { foo: 345 } }
+  };
+  describe("authorize()", () => {
+    it("should return true when a definition without authorize() method is given", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(customCommandReqData);
+      assert.strictEqual(result, true);
+    });
+
+    it("should return the result of a given definition's authorize() method when it exists", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          authorize: async () => false
+        } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.authorize(customCommandReqData);
+      assert.strictEqual(result, false);
+    });
+  });
+
+  describe("validate()", () => {
+    it("should do nothing when a definition without validate() method is given", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomCommandDefinition,
+        clientMock
+      );
+      await executor.validate(customCommandReqData);
+      assert.ok(true);
+    });
+
+    it("should run a given definition's validate() method when it exists", async () => {
+      let counter = 0;
+      const executor = new CustomCommandDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          validate: async () => {
+            counter++;
+            return;
+          }
+        } as CustomCommandDefinition,
+        clientMock
+      );
+      await executor.validate(customCommandReqData);
+      assert.strictEqual(counter, 1);
+    });
+  });
+
+  describe("normalize()", () => {
+    it("should return the same RequestData when a definition without normalize() method is given", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(customCommandReqData);
+      assert.strictEqual(result, customCommandReqData);
+    });
+
+    it("should return the result of a given definition's normalize() method when it exists", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          normalize: async () =>
+            Object.assign({}, customCommandReqData, { ex: 1 })
+        } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.normalize(customCommandReqData);
+      assert.deepStrictEqual(
+        result,
+        Object.assign({}, customCommandReqData, { ex: 1 })
+      );
+    });
+  });
+
+  describe("execute()", () => {
+    it("should return the result of exexute() when a given definition has no wrapExecution() method", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        { execute: async () => ({ result: 123 }) } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.execute(customCommandReqData);
+      assert.deepStrictEqual(result, {
+        type: "runCustomCommand",
+        payload: { result: 123 }
+      });
+    });
+
+    it("should return the wrapped result of a given definition's wrapExecution() method when it exists", async () => {
+      const executor = new CustomCommandDefinitionExecutor(
+        {
+          execute: async () => ({ result: 123 }),
+          wrapExecution: async () => ({
+            type: "runCustomCommand",
+            payload: { result: 345 }
+          })
+        } as CustomCommandDefinition,
+        clientMock
+      );
+      const result = await executor.execute(customCommandReqData);
+      assert.deepStrictEqual(result, {
+        type: "runCustomCommand",
+        payload: { result: 345 }
+      });
+    });
+  });
+});


### PR DESCRIPTION
As the original implementation contained the following bug:

Login logic cannot be called when a UserDefinition doesn't have `wrapExecution()` method.