### PR TITLE
Convert optional function properties into optional methods

### DIFF
--- a/modules/interfaces/src/custom-command-definition.ts
+++ b/modules/interfaces/src/custom-command-definition.ts
@@ -5,20 +5,20 @@ import { GeneralDefinition } from "./entity-definition";
 import { Session } from "./session";
 
 export interface CustomCommandDefinition extends GeneralDefinition {
-  authorize?: (
+  authorize?(
     reqData: GeneralCustomCommandRequestData,
     session?: Session
-  ) => Promise<boolean>;
+  ): Promise<boolean>;
 
-  normalize?: (
+  normalize?(
     reqData: GeneralCustomCommandRequestData,
     session?: Session
-  ) => Promise<GeneralCustomCommandRequestData>;
+  ): Promise<GeneralCustomCommandRequestData>;
 
-  validate?: (
+  validate?(
     reqData: GeneralCustomCommandRequestData,
     session?: Session
-  ) => Promise<void>;
+  ): Promise<void>;
 
   execute(
     command: CustomCommand,

--- a/modules/interfaces/src/custom-query-definition.ts
+++ b/modules/interfaces/src/custom-query-definition.ts
@@ -5,20 +5,20 @@ import { GeneralDefinition } from "./entity-definition";
 import { Session } from "./session";
 
 export interface CustomQueryDefinition extends GeneralDefinition {
-  authorize?: (
+  authorize?(
     reqData: GeneralCustomQueryRequestData,
     session?: Session
-  ) => Promise<boolean>;
+  ): Promise<boolean>;
 
-  normalize?: (
+  normalize?(
     reqData: GeneralCustomQueryRequestData,
     session?: Session
-  ) => Promise<GeneralCustomQueryRequestData>;
+  ): Promise<GeneralCustomQueryRequestData>;
 
-  validate?: (
+  validate?(
     reqData: GeneralCustomQueryRequestData,
     session?: Session
-  ) => Promise<void>;
+  ): Promise<void>;
 
   execute(query: CustomQuery, session?: Session): Promise<CustomQueryResult>;
 }

--- a/modules/interfaces/src/entity-definition.ts
+++ b/modules/interfaces/src/entity-definition.ts
@@ -7,47 +7,44 @@ import {
 import { Session } from "./session";
 
 export interface GeneralDefinition {
-  authorize?: (
+  authorize?(reqData: GeneralRequestData, session?: Session): Promise<boolean>;
+
+  normalize?(
     reqData: GeneralRequestData,
     session?: Session
-  ) => Promise<boolean>;
+  ): Promise<GeneralRequestData>;
 
-  normalize?: (
-    reqData: GeneralRequestData,
-    session?: Session
-  ) => Promise<GeneralRequestData>;
+  validate?(reqData: GeneralRequestData, session?: Session): Promise<void>;
 
-  validate?: (reqData: GeneralRequestData, session?: Session) => Promise<void>;
-
-  wrapExecution?: (
+  wrapExecution?(
     reqData: GeneralRequestData,
     session: Session | undefined,
     executeFn: (
       reqData: GeneralRequestData,
       session?: Session
     ) => Promise<GeneralResponseData>
-  ) => Promise<GeneralResponseData>;
+  ): Promise<GeneralResponseData>;
 }
 
 export interface EntityDefinition extends GeneralDefinition {
-  authorize?: (
+  authorize?(
     reqData: GeneralEntityRequestData,
     session?: Session
-  ) => Promise<boolean>;
+  ): Promise<boolean>;
 
-  normalize?: (
+  normalize?(
     reqData: GeneralEntityRequestData,
     session?: Session
-  ) => Promise<GeneralEntityRequestData>;
+  ): Promise<GeneralEntityRequestData>;
 
-  validate?: (reqData: GeneralRequestData, session?: Session) => Promise<void>;
+  validate?(reqData: GeneralRequestData, session?: Session): Promise<void>;
 
-  wrapExecution?: (
+  wrapExecution?(
     reqData: GeneralEntityRequestData,
     session: Session | undefined,
     executeFn: (
       reqData: GeneralEntityRequestData,
       session?: Session
     ) => Promise<GeneralEntityResponseData>
-  ) => Promise<GeneralEntityResponseData>;
+  ): Promise<GeneralEntityResponseData>;
 }

--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -1,5 +1,5 @@
 import { Entity } from "./entity";
-import { EntityDefinition } from "./entity-definition";
+import { GeneralDefinition } from "./entity-definition";
 import { LoginCommand } from "./command";
 import { PreSession } from "./session";
 import { Session } from "./session";
@@ -16,7 +16,7 @@ export type AuthenticationResult<
   versionId: string | null;
 };
 
-export interface UserDefinition extends EntityDefinition {
+export interface UserDefinition extends GeneralDefinition {
   authenticate(
     loginCommand: LoginCommand,
     session?: Session
@@ -27,21 +27,21 @@ export interface UserDefinition extends EntityDefinition {
     session?: Session
   ): Promise<boolean>;
 
-  normalize?<T extends UserEntityRequestData>(
-    reqData: T,
+  normalize?(
+    reqData: UserEntityRequestData,
     session?: Session
-  ): Promise<T>;
+  ): Promise<UserEntityRequestData>;
 
   validate?(reqData: UserEntityRequestData, session?: Session): Promise<void>;
 
-  wrapExecution?<
-    T extends UserEntityRequestData,
-    S extends UserEntityResponseData
-  >(
-    reqData: T,
+  wrapExecution?(
+    reqData: UserEntityRequestData,
     session: Session,
-    executeFn: (reqData: T, session?: Session) => Promise<S>
-  ): Promise<S>;
+    executeFn: (
+      reqData: UserEntityRequestData,
+      session?: Session
+    ) => Promise<UserEntityResponseData>
+  ): Promise<UserEntityResponseData>;
 }
 
 export type AuthDefinition = Pick<UserDefinition, "authenticate">;

--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -1,5 +1,5 @@
 import { Entity } from "./entity";
-import { GeneralDefinition } from "./entity-definition";
+import { EntityDefinition } from "./entity-definition";
 import { LoginCommand } from "./command";
 import { PreSession } from "./session";
 import { Session } from "./session";
@@ -16,35 +16,32 @@ export type AuthenticationResult<
   versionId: string | null;
 };
 
-export interface UserDefinition extends GeneralDefinition {
+export interface UserDefinition extends EntityDefinition {
   authenticate(
     loginCommand: LoginCommand,
     session?: Session
   ): Promise<AuthenticationResult>;
 
-  authorize?: (
+  authorize?(
     reqData: UserEntityRequestData,
     session?: Session
-  ) => Promise<boolean>;
+  ): Promise<boolean>;
 
-  normalize?: (
-    reqData: UserEntityRequestData,
+  normalize?<T extends UserEntityRequestData>(
+    reqData: T,
     session?: Session
-  ) => Promise<UserEntityRequestData>;
+  ): Promise<T>;
 
-  validate?: (
-    reqData: UserEntityRequestData,
-    session?: Session
-  ) => Promise<void>;
+  validate?(reqData: UserEntityRequestData, session?: Session): Promise<void>;
 
-  wrapExecution?: (
-    reqData: UserEntityRequestData,
+  wrapExecution?<
+    T extends UserEntityRequestData,
+    S extends UserEntityResponseData
+  >(
+    reqData: T,
     session: Session,
-    executeFn: (
-      reqData: UserEntityRequestData,
-      session?: Session
-    ) => Promise<UserEntityResponseData>
-  ) => Promise<UserEntityResponseData>;
+    executeFn: (reqData: T, session?: Session) => Promise<S>
+  ): Promise<S>;
 }
 
 export type AuthDefinition = Pick<UserDefinition, "authenticate">;


### PR DESCRIPTION
In Typescript, function properties and optional methods are slightly different when they are extended. Bivariance can be allowed to arguments of methods, not that of function properties.

`@phenyl/interfaces` should provide rather flexible types such as bivariance than forcing strict types. Therefore, `Definition` interfaces now have methods, not function properties.
