### PR TITLE
Fix session argument's optionality

### DIFF
--- a/modules/standards/src/foreign-query-wrapper.ts
+++ b/modules/standards/src/foreign-query-wrapper.ts
@@ -43,7 +43,7 @@ export class ForeignQueryWrapper<M extends GeneralEntityMap> {
    */
   async validation(
     reqData: GeneralRequestData,
-    session: Session | null | undefined
+    session?: Session
   ): Promise<void> {
     // eslint-disable-line no-unused-vars
     return switchByRequestMethod(reqData, {

--- a/modules/standards/src/standard-entity-definition.ts
+++ b/modules/standards/src/standard-entity-definition.ts
@@ -15,7 +15,7 @@ export class StandardEntityDefinition implements EntityDefinition {
 
   async authorize(
     reqData: GeneralRequestData,
-    session: Session | null | undefined
+    session?: Session
   ): Promise<boolean> {
     // TODO
     return false;
@@ -23,7 +23,7 @@ export class StandardEntityDefinition implements EntityDefinition {
 
   async validate(
     reqData: GeneralRequestData,
-    session: Session | null | undefined
+    session?: Session
   ): Promise<void> {
     // eslint-disable-line no-unused-vars
   }

--- a/modules/standards/src/standard-user-definition.ts
+++ b/modules/standards/src/standard-user-definition.ts
@@ -56,7 +56,7 @@ export class StandardUserDefinition<
 
   async authenticate<N extends Key<M>>(
     loginCommand: LoginCommandOf<A, N>,
-    session: Session | null | undefined
+    session?: Session
   ): Promise<AuthenticationResult<string, any>> {
     const { accountPropName, passwordPropName, ttl } = this;
     const { credentials, entityName } = loginCommand;
@@ -86,7 +86,7 @@ export class StandardUserDefinition<
 
   async wrapExecution(
     reqData: UserEntityRequestData,
-    session: Session,
+    session: Session | undefined,
     executeFn: (
       reqData: UserEntityRequestData,
       session?: Session


### PR DESCRIPTION
* In `StandardUserDefinition`, `session` can be optional.
* `session` argument can be `undefined` but `null`.