### PR TITLE
Name execute functions passed to wrapExecution in EntityDefinition

### DIFF
--- a/modules/interfaces/src/custom-command-definition.ts
+++ b/modules/interfaces/src/custom-command-definition.ts
@@ -25,3 +25,8 @@ export interface CustomCommandDefinition extends GeneralDefinition {
     session?: Session
   ): Promise<GeneralCustomCommandResult>;
 }
+
+export type GeneralCustomCommandExecuteFn = (
+  query: GeneralCustomCommand,
+  session?: Session
+) => Promise<GeneralCustomCommandResult>;

--- a/modules/interfaces/src/custom-query-definition.ts
+++ b/modules/interfaces/src/custom-query-definition.ts
@@ -25,3 +25,8 @@ export interface CustomQueryDefinition extends GeneralDefinition {
     session?: Session
   ): Promise<GeneralCustomQueryResult>;
 }
+
+export type GeneralCustomQueryExecuteFn = (
+  query: GeneralCustomQuery,
+  session?: Session
+) => Promise<GeneralCustomQueryResult>;

--- a/modules/interfaces/src/entity-definition.ts
+++ b/modules/interfaces/src/entity-definition.ts
@@ -26,6 +26,11 @@ export interface GeneralDefinition {
   ): Promise<GeneralResponseData>;
 }
 
+export type GeneralExecuteFn = (
+  reqData: GeneralRequestData,
+  session?: Session
+) => Promise<GeneralResponseData>;
+
 export interface EntityDefinition extends GeneralDefinition {
   authorize?(
     reqData: GeneralEntityRequestData,
@@ -48,3 +53,8 @@ export interface EntityDefinition extends GeneralDefinition {
     ) => Promise<GeneralEntityResponseData>
   ): Promise<GeneralEntityResponseData>;
 }
+
+export type GeneralEntityExecuteFn = (
+  reqData: GeneralEntityRequestData,
+  session?: Session
+) => Promise<GeneralEntityResponseData>;

--- a/modules/interfaces/src/response-data.ts
+++ b/modules/interfaces/src/response-data.ts
@@ -106,9 +106,9 @@ export type GeneralAuthResponseData =
  * By inputting types to the definition, the type parameters of this type are inferred in the definition's methods.
  */
 export type UserEntityResponseData<
-  EN extends string = string,
-  E extends Entity = Entity,
-  S extends Object = Object
+  EN extends string,
+  E extends Entity,
+  S extends Object
 > = EntityResponseData<E> | AuthResponseData<EN, E, S>;
 
 export type GeneralUserEntityResponseData =

--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -51,3 +51,8 @@ export interface UserDefinition extends GeneralDefinition {
 export type UserEntityDefinition = UserDefinition;
 
 export type AuthDefinition = Pick<UserDefinition, "authenticate">;
+
+export type GeneralUserEntityExecuteFn = (
+  reqData: GeneralUserEntityRequestData,
+  session?: Session
+) => Promise<GeneralUserEntityResponseData>;

--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -4,7 +4,7 @@ import { GeneralLoginCommand } from "./command";
 import { PreSession } from "./session";
 import { Session } from "./session";
 import { GeneralUserEntityRequestData } from "./request-data";
-import { UserEntityResponseData } from "./response-data";
+import { GeneralUserEntityResponseData } from "./response-data";
 
 export type AuthenticationResult<
   EN extends string = string,
@@ -43,8 +43,11 @@ export interface UserDefinition extends GeneralDefinition {
     executeFn: (
       reqData: GeneralUserEntityRequestData,
       session?: Session
-    ) => Promise<UserEntityResponseData>
-  ): Promise<UserEntityResponseData>;
+    ) => Promise<GeneralUserEntityResponseData>
+  ): Promise<GeneralUserEntityResponseData>;
 }
+
+// alias
+export type UserEntityDefinition = UserDefinition;
 
 export type AuthDefinition = Pick<UserDefinition, "authenticate">;

--- a/modules/rest-api/src/definition-executor.ts
+++ b/modules/rest-api/src/definition-executor.ts
@@ -21,7 +21,7 @@ import {
   Session,
   SessionClient,
   UserDefinition,
-  UserEntityResponseData
+  GeneralUserEntityResponseData
 } from "@phenyl/interfaces";
 
 import { ErrorResponseData } from "@phenyl/interfaces";
@@ -212,7 +212,7 @@ export class UserDefinitionExecutor extends DefinitionExecutor {
   async executeOwn(
     reqData: GeneralUserEntityRequestData,
     session?: Session
-  ): Promise<UserEntityResponseData> {
+  ): Promise<GeneralUserEntityResponseData> {
     if (reqData.method == "logout") {
       return this.logout(reqData.payload);
     }

--- a/modules/standards/src/standard-user-definition.ts
+++ b/modules/standards/src/standard-user-definition.ts
@@ -15,7 +15,7 @@ import {
   Session,
   AuthenticationResult,
   GeneralUserEntityRequestData,
-  UserEntityResponseData,
+  GeneralUserEntityResponseData,
   GeneralEntityMap
 } from "@phenyl/interfaces";
 
@@ -90,8 +90,8 @@ export class StandardUserDefinition<
     executeFn: (
       reqData: GeneralUserEntityRequestData,
       session?: Session
-    ) => Promise<UserEntityResponseData>
-  ): Promise<UserEntityResponseData> {
+    ) => Promise<GeneralUserEntityResponseData>
+  ): Promise<GeneralUserEntityResponseData> {
     const newReqData = encryptPasswordInRequestData(
       reqData,
       this.passwordPropName,


### PR DESCRIPTION
1. Name execute functions passed to wrapExecution in EntityDefinition
2. Fix bug: UserEntityResponseData should be generalized