### PR TITLE
Set strictFunctionTypes to true

### DIFF
--- a/modules/api-explorer-client/tsconfig.json
+++ b/modules/api-explorer-client/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "strictFunctionTypes": false,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "moduleResolution": "node",

--- a/modules/interfaces/src/http-server.ts
+++ b/modules/interfaces/src/http-server.ts
@@ -7,14 +7,20 @@ import { RestApiHandler, GeneralRestApiHandler } from "./rest-api-handler";
 export interface GeneralServerParams {
   restApiHandler: GeneralRestApiHandler;
   modifyPath?: PathModifier;
-  customRequestHandler?: GeneralCustomRequestHandler;
+  customRequestHandler?(
+    encodedHttpRequest: EncodedHttpRequest,
+    restApiClient: GeneralRestApiClient
+  ): Promise<EncodedHttpResponse>;
 }
 
 export interface ServerParams<TM extends GeneralTypeMap>
   extends GeneralServerParams {
   restApiHandler: RestApiHandler<TM>;
   modifyPath?: PathModifier;
-  customRequestHandler?: CustomRequestHandler<TM>;
+  customRequestHandler?(
+    encodedHttpRequest: EncodedHttpRequest,
+    restApiClient: RestApiClient<TM>
+  ): Promise<EncodedHttpResponse>;
 }
 
 /**
@@ -39,16 +45,14 @@ export type PathModifier = (path: string) => string;
  *
  * When you need to pass `TypeMap`, use `CustomRequestHandler` instead.
  */
-export type GeneralCustomRequestHandler = (
-  encodedHttpRequest: EncodedHttpRequest,
-  restApiClient: GeneralRestApiClient
-) => Promise<EncodedHttpResponse>;
+export type GeneralCustomRequestHandler = Required<
+  GeneralServerParams
+>["customRequestHandler"];
 
 /**
  * Custom Request Handler.
  * See `GeneralCustomRequestHandler` for details.
  */
-export type CustomRequestHandler<TM extends GeneralTypeMap> = (
-  encodedHttpRequest: EncodedHttpRequest,
-  restApiClient: RestApiClient<TM>
-) => Promise<EncodedHttpResponse>;
+export type CustomRequestHandler<TM extends GeneralTypeMap> = Required<
+  ServerParams<TM>
+>["customRequestHandler"];

--- a/modules/mongodb/src/connection.ts
+++ b/modules/mongodb/src/connection.ts
@@ -120,10 +120,11 @@ function promisifyFindChain(find: (where?: Object) => Object): PromisifiedFind {
     const findChain = find(where);
     const newFindChain = Object.keys(params).reduce(
       (chain, name) =>
-        // @ts-ignore fix this latter
+        // @ts-ignore #278
         chain[name](params[name]),
       findChain
     );
+    // @ts-ignore #278
     return promisify(newFindChain.toArray, newFindChain)();
   };
 }

--- a/modules/mongodb/src/mongodb-client.ts
+++ b/modules/mongodb/src/mongodb-client.ts
@@ -168,7 +168,8 @@ export class PhenylMongoDbClient<M extends GeneralEntityMap>
     if (sort) options.sort = sort;
 
     const result = await coll.find(filterFindOperation(where), options);
-    return result.map<any>(restoreIdInEntity);
+    // @ts-ignore #278
+    return result.map(restoreIdInEntity);
   }
 
   async findOne<N extends Key<M>>(
@@ -213,7 +214,8 @@ export class PhenylMongoDbClient<M extends GeneralEntityMap>
         "NotFound"
       );
     }
-    return result.map<any>(restoreIdInEntity);
+    // @ts-ignore #278
+    return result.map(restoreIdInEntity);
   }
 
   async insertOne<N extends Key<M>>(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,6 @@
     "moduleResolution": "Node",
     "noUnusedLocals": true,
     "strict": true,
-    "strictFunctionTypes": false,
     "target": "es5"
   },
   "exclude": ["node_modules"]


### PR DESCRIPTION
The purpose is for library users not to run into troubles related to strictFunctionTypes.
Although in api-explorer-client the flag still remains false, it's OK because it's a tool and not a library.