### PR TITLE
Improve type and implementation of StandardEntityDefinition and StandardUserDefinition

### DIFF
--- a/modules/interfaces/src/user-definition.ts
+++ b/modules/interfaces/src/user-definition.ts
@@ -7,20 +7,26 @@ import { GeneralUserEntityRequestData } from "./request-data";
 import { GeneralUserEntityResponseData } from "./response-data";
 
 export type AuthenticationResult<
-  EN extends string = string,
-  E extends Entity = Entity,
-  S extends Object = Object
+  EN extends string,
+  E extends Entity,
+  S extends Object
 > = {
   preSession: PreSession<EN, S>;
   user: E | null;
   versionId: string | null;
 };
 
+export type GeneralAuthenticationResult = AuthenticationResult<
+  string,
+  Entity,
+  Object
+>;
+
 export interface UserDefinition extends GeneralDefinition {
   authenticate(
     loginCommand: GeneralLoginCommand,
     session?: Session
-  ): Promise<AuthenticationResult>;
+  ): Promise<GeneralAuthenticationResult>;
 
   authorize?(
     reqData: GeneralUserEntityRequestData,

--- a/modules/rest-api/test/defiintion-executor.test.ts
+++ b/modules/rest-api/test/defiintion-executor.test.ts
@@ -1,5 +1,5 @@
 import {
-  AuthenticationResult,
+  GeneralAuthenticationResult,
   CustomCommandDefinition,
   CustomQueryDefinition,
   EntityClient,
@@ -151,7 +151,7 @@ describe("UserDefinitionExecutor", () => {
     });
 
     it("should return the result of a given definition's authorize() method when it exists", async () => {
-      const authenticate = async () => ({} as AuthenticationResult);
+      const authenticate = async () => ({} as GeneralAuthenticationResult);
       const executor = new UserDefinitionExecutor(
         { authenticate, authorize: async () => false } as UserDefinition,
         clientMock,
@@ -175,7 +175,7 @@ describe("UserDefinitionExecutor", () => {
 
     it("should run a given definition's validate() method when it exists", async () => {
       let counter = 0;
-      const authenticate = async () => ({} as AuthenticationResult);
+      const authenticate = async () => ({} as GeneralAuthenticationResult);
       const executor = new UserDefinitionExecutor(
         {
           authenticate,
@@ -204,7 +204,7 @@ describe("UserDefinitionExecutor", () => {
     });
 
     it("should return the result of a given definition's normalize() method when it exists", async () => {
-      const authenticate = async () => ({} as AuthenticationResult);
+      const authenticate = async () => ({} as GeneralAuthenticationResult);
       const executor = new UserDefinitionExecutor(
         { authenticate, normalize: async () => findReqData2 } as UserDefinition,
         clientMock,
@@ -227,7 +227,7 @@ describe("UserDefinitionExecutor", () => {
     });
 
     it("should return the wrapped result of a given definition's wrapExecution() method when it exists", async () => {
-      const authenticate = async () => ({} as AuthenticationResult);
+      const authenticate = async () => ({} as GeneralAuthenticationResult);
       const executor = new UserDefinitionExecutor(
         {
           authenticate,
@@ -243,7 +243,7 @@ describe("UserDefinitionExecutor", () => {
     it("should run definition's authenticate() method when LoginRequestData is given", async () => {
       // @ts-ignore
       const authenticate = async () =>
-        ({ versionId: "abcd" } as AuthenticationResult);
+        ({ versionId: "abcd" } as GeneralAuthenticationResult);
       const executor = new UserDefinitionExecutor(
         {
           authenticate

--- a/modules/standards/src/index.ts
+++ b/modules/standards/src/index.ts
@@ -1,8 +1,5 @@
 export { StandardEntityDefinition } from "./standard-entity-definition";
-export {
-  GeneralStandardUserDefinition,
-  StandardUserDefinition
-} from "./standard-user-definition";
+export { StandardUserDefinition } from "./standard-user-definition";
 export {
   encryptPasswordInRequestData
 } from "./encrypt-password-in-request-data";

--- a/modules/standards/src/standard-entity-definition.ts
+++ b/modules/standards/src/standard-entity-definition.ts
@@ -4,27 +4,16 @@ import {
   Session
 } from "@phenyl/interfaces";
 
-type AuthorizationSetting = {};
-
+/**
+ * [deprecated] Standard entity definition.
+ * You don't need to extend this almost-doing-nothing class.
+ * Instead, implements `EntityDefinition`.
+ */
 export class StandardEntityDefinition implements EntityDefinition {
-  authorizationSetting: AuthorizationSetting;
-
-  constructor(authorizationSetting: AuthorizationSetting) {
-    this.authorizationSetting = authorizationSetting;
-  }
-
   async authorize(
     reqData: GeneralRequestData,
     session?: Session
   ): Promise<boolean> {
-    // TODO
     return false;
-  }
-
-  async validate(
-    reqData: GeneralRequestData,
-    session?: Session
-  ): Promise<void> {
-    // eslint-disable-line no-unused-vars
   }
 }


### PR DESCRIPTION
1. Deprecate StandardEntityDefinition
2. Don't take type parameter in StandardUserDefinition