### PR TITLE
Make FunctionalGroup generic

### DIFF
--- a/modules/api-explorer-client/src/@types/global.d.ts
+++ b/modules/api-explorer-client/src/@types/global.d.ts
@@ -1,9 +1,9 @@
-import { FunctionalGroup } from "@phenyl/interfaces";
+import { GeneralFunctionalGroup } from "@phenyl/interfaces";
 
 declare global {
   interface Window {
     phenylApiExplorerClientGlobals: {
-      PhenylFunctionalGroupSkeleton: FunctionalGroup;
+      PhenylFunctionalGroupSkeleton: GeneralFunctionalGroup;
       phenylApiUrlBase: string;
     };
   }

--- a/modules/api-explorer/examples/index.ts
+++ b/modules/api-explorer/examples/index.ts
@@ -15,7 +15,7 @@ import {
   CustomQuery,
   CustomQueryDefinition,
   CustomQueryResult,
-  FunctionalGroup,
+  GeneralFunctionalGroup,
   ReqRes,
   KvsClient
 } from "@phenyl/interfaces";
@@ -58,10 +58,7 @@ type AppEntityMap = {
 
 const memoryClient = createEntityClient<AppEntityMap>();
 
-class PatientDefinition extends StandardUserDefinition<
-  AppReqResEntityMap,
-  PatientAuthSetting
-> {
+class PatientDefinition extends StandardUserDefinition {
   constructor() {
     super({
       entityClient: memoryClient,
@@ -108,10 +105,8 @@ class TestCustomCommand implements CustomCommandDefinition {
     session?: Session
   ): Promise<CustomCommandResult<CustomCommandResponse>> {
     return {
-      result: {
-        echo: command.params.echo,
-        session
-      }
+      echo: command.params.echo,
+      session
     };
   }
 }
@@ -140,15 +135,13 @@ class TestCustomQuery implements CustomQueryDefinition {
     session?: Session
   ): Promise<CustomQueryResult<CustomQueryResponse>> {
     return {
-      result: {
-        echo: command.params.echo,
-        session
-      }
+      echo: command.params.echo,
+      session
     };
   }
 }
 
-const functionalGroup: FunctionalGroup = {
+const functionalGroup: GeneralFunctionalGroup = {
   customQueries: {
     test: new TestCustomCommand()
   },
@@ -159,7 +152,7 @@ const functionalGroup: FunctionalGroup = {
     patient: new PatientDefinition()
   },
   nonUsers: {
-    hospital: new HospitalDefinition({})
+    hospital: new HospitalDefinition()
   }
 };
 

--- a/modules/api-explorer/src/PhenylApiExplorer.ts
+++ b/modules/api-explorer/src/PhenylApiExplorer.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import ejs from "ejs";
 import {
-  FunctionalGroup,
+  GeneralFunctionalGroup,
   EncodedHttpResponse,
   EncodedHttpRequest
 } from "@phenyl/interfaces";
@@ -13,12 +13,12 @@ export type ExplorerParams = {
   phenylApiUrlBase?: string;
 };
 export default class PhenylApiExplorer {
-  functionalGroup: FunctionalGroup;
+  functionalGroup: GeneralFunctionalGroup;
   path: string;
   phenylApiUrlBase: string;
   html: string;
 
-  constructor(functionalGroup: FunctionalGroup, params: ExplorerParams) {
+  constructor(functionalGroup: GeneralFunctionalGroup, params: ExplorerParams) {
     this.functionalGroup = functionalGroup;
     this.path = params.path;
     this.phenylApiUrlBase = params.phenylApiUrlBase || "";

--- a/modules/express/test/index.test.ts
+++ b/modules/express/test/index.test.ts
@@ -16,7 +16,8 @@ import {
   GeneralRestApiHandler,
   EncodedHttpRequest,
   GeneralTypeMap,
-  ReqRes
+  ReqRes,
+  FunctionalGroup
 } from "@phenyl/interfaces";
 
 type Diary = ReqRes<{ id: string }>;
@@ -46,10 +47,6 @@ class GetVersionDefinition implements CustomQueryDefinition {
   }
 }
 
-type EntityMap = {
-  member: any;
-  diary: any;
-};
 type MemberRequest = { id: string };
 type MemberResponse = { id: string; name: string; age: number };
 type MemberSessionValue = { externalId: string; ttl: number };
@@ -80,17 +77,6 @@ class MemberDefinition implements EntityDefinition {
   }
 }
 
-const fg = {
-  users: { member: new MemberDefinition() },
-  nonUsers: {
-    diary: new DiaryDefinition()
-  },
-  customQueries: {
-    getVersion: new GetVersionDefinition()
-  },
-  customCommands: {}
-};
-
 interface MyTypeMap extends GeneralTypeMap {
   entities: {
     member: ReqRes<MemberRequest, MemberResponse>;
@@ -105,10 +91,25 @@ interface MyTypeMap extends GeneralTypeMap {
       };
     };
   };
+  auths: {
+    member: {
+      credentials: Object;
+    };
+  };
 }
 
-const restApiHandler = new PhenylRestApi<MyTypeMap>(fg, {
-  entityClient: createEntityClient<EntityMap>()
+const fg: FunctionalGroup<MyTypeMap> = {
+  users: { member: new MemberDefinition() },
+  nonUsers: {
+    diary: new DiaryDefinition()
+  },
+  customQueries: {
+    getVersion: new GetVersionDefinition()
+  }
+};
+
+const restApiHandler = new PhenylRestApi(fg, {
+  entityClient: createEntityClient()
 });
 
 describe("createPhenylApiMiddleware", () => {

--- a/modules/interfaces/src/client.ts
+++ b/modules/interfaces/src/client.ts
@@ -248,6 +248,7 @@ export interface ReqResEntityClient<M extends GeneralReqResEntityMap>
 export interface GeneralEntityClient extends BaseEntityClient {
   getDbClient(): GeneralDbClient;
   createSessionClient(): GeneralSessionClient;
+  createSessionClient<AM extends GeneralAuthCommandMap>(): SessionClient<AM>;
 }
 
 /**

--- a/modules/interfaces/src/functional-group.ts
+++ b/modules/interfaces/src/functional-group.ts
@@ -2,6 +2,13 @@ import { CustomCommandDefinition } from "./custom-command-definition";
 import { CustomQueryDefinition } from "./custom-query-definition";
 import { EntityDefinition } from "./entity-definition";
 import { UserDefinition } from "./user-definition";
+import {
+  GeneralTypeMap,
+  UserEntityNameOf,
+  NonUserEntityNameOf,
+  CustomQueryNameOf,
+  CustomCommandNameOf
+} from "./type-map";
 
 export type EntityDefinitions = {
   [EntityName: string]: EntityDefinition;
@@ -19,11 +26,23 @@ export type UserDefinitions = {
   [EntityName: string]: UserDefinition;
 };
 
-export type NormalizedFunctionalGroup = {
+export type GeneralNormalizedFunctionalGroup = {
   users: UserDefinitions;
   nonUsers: EntityDefinitions;
   customQueries: CustomQueryDefinitions;
   customCommands: CustomCommandDefinitions;
 };
 
-export type FunctionalGroup = Partial<NormalizedFunctionalGroup>;
+export interface NormalizedFunctionalGroup<TM extends GeneralTypeMap>
+  extends GeneralNormalizedFunctionalGroup {
+  users: { [AN in UserEntityNameOf<TM>]: UserDefinition };
+  nonUsers: { [EN in NonUserEntityNameOf<TM>]: EntityDefinition };
+  customQueries: { [QN in CustomQueryNameOf<TM>]: CustomQueryDefinition };
+  customCommands: { [CN in CustomCommandNameOf<TM>]: CustomCommandDefinition };
+}
+
+export type FunctionalGroup<TM extends GeneralTypeMap> = Partial<
+  NormalizedFunctionalGroup<TM>
+>;
+
+export type GeneralFunctionalGroup = Partial<GeneralNormalizedFunctionalGroup>;

--- a/modules/interfaces/src/type-map.ts
+++ b/modules/interfaces/src/type-map.ts
@@ -371,6 +371,20 @@ export type AuthCommandOf<
 export type AuthEntityNameOf<TM extends GeneralTypeMap> = Key<TM["auths"]>;
 
 /**
+ * Name of auths in given TypeMap.
+ * Alias for AuthEntityNameOf
+ */
+export type UserEntityNameOf<TM extends GeneralTypeMap> = AuthEntityNameOf<TM>;
+
+/**
+ * Name of non-user entities in given TypeMap.
+ */
+export type NonUserEntityNameOf<TM extends GeneralTypeMap> = Exclude<
+  EntityNameOf<TM>,
+  UserEntityNameOf<TM>
+>;
+
+/**
  * Credential values of given user entity name in given TypeMap.
  */
 export type AuthCredentialsOf<

--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -21,7 +21,6 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@phenyl/central-state": "^1.1.1",
     "@phenyl/interfaces": "^1.1.1",
     "@phenyl/utils": "^1.1.1"
   },

--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -16,14 +16,15 @@ import {
   ResponseEntityMapOf,
   ErrorResponseData,
   GeneralRestApiHandler,
-  GeneralFunctionalGroup
+  GeneralFunctionalGroup,
+  GeneralSessionClient,
+  GeneralEntityClient
 } from "@phenyl/interfaces";
 import {
   PhenylRestApiDirectClient,
   assertValidRequestData,
   createServerError
 } from "@phenyl/utils";
-import { PhenylSessionClient } from "@phenyl/central-state";
 
 import {
   CustomCommandDefinitionExecutor,
@@ -54,14 +55,14 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
   constructor(
     fg: FunctionalGroup<TM>,
     params: {
-      entityClient: EntityClient<ResponseEntityMapOf<TM>>;
-      sessionClient?: SessionClient<AuthCommandMapOf<TM>>;
+      entityClient: GeneralEntityClient;
+      sessionClient?: GeneralSessionClient;
     }
   ) {
     this.client = params.entityClient;
     this.sessionClient =
-      params.sessionClient ||
-      new PhenylSessionClient<AuthCommandMapOf<TM>>(this.client.getDbClient());
+      (params.sessionClient as SessionClient<AuthCommandMapOf<TM>>) ||
+      this.client.createSessionClient<AuthCommandMapOf<TM>>();
     this.definitionExecutors = this.createDefinitionExecutors(fg);
   }
 

--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -15,7 +15,8 @@ import {
   VersionDiffPublisher,
   ResponseEntityMapOf,
   ErrorResponseData,
-  GeneralRestApiHandler
+  GeneralRestApiHandler,
+  GeneralFunctionalGroup
 } from "@phenyl/interfaces";
 import {
   PhenylRestApiDirectClient,
@@ -51,7 +52,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
   private readonly definitionExecutors: DefinitionExecutorMap;
 
   constructor(
-    fg: FunctionalGroup,
+    fg: FunctionalGroup<TM>,
     params: {
       entityClient: EntityClient<ResponseEntityMapOf<TM>>;
       sessionClient?: SessionClient<AuthCommandMapOf<TM>>;
@@ -184,7 +185,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
   }
 
   private createDefinitionExecutors(
-    fg: FunctionalGroup
+    fg: GeneralFunctionalGroup
   ): DefinitionExecutorMap {
     const user = fg.users
       ? Object.entries(fg.users).reduce(

--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -47,7 +47,7 @@ type DefinitionExecutorMap = {
  */
 export class PhenylRestApi<TM extends GeneralTypeMap>
   implements RestApiHandler<TM>, GeneralRestApiHandler {
-  readonly client: EntityClient<ResponseEntityMapOf<TM>>;
+  readonly entityClient: EntityClient<ResponseEntityMapOf<TM>>;
   readonly sessionClient: SessionClient<AuthCommandMapOf<TM>>;
   readonly versionDiffPublisher: Nullable<VersionDiffPublisher>;
   private readonly definitionExecutors: DefinitionExecutorMap;
@@ -59,11 +59,15 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
       sessionClient?: GeneralSessionClient;
     }
   ) {
-    this.client = params.entityClient;
+    this.entityClient = params.entityClient;
     this.sessionClient =
       (params.sessionClient as SessionClient<AuthCommandMapOf<TM>>) ||
-      this.client.createSessionClient<AuthCommandMapOf<TM>>();
+      this.entityClient.createSessionClient<AuthCommandMapOf<TM>>();
     this.definitionExecutors = this.createDefinitionExecutors(fg);
+  }
+
+  get client(): EntityClient<ResponseEntityMapOf<TM>> {
+    return this.entityClient;
   }
 
   /**
@@ -194,7 +198,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
             ...acc,
             [name]: new UserDefinitionExecutor(
               def,
-              this.client,
+              this.entityClient,
               this.sessionClient
             )
           }),
@@ -205,7 +209,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
       ? Object.entries(fg.nonUsers).reduce(
           (acc, [name, def]) => ({
             ...acc,
-            [name]: new EntityDefinitionExecutor(def, this.client)
+            [name]: new EntityDefinitionExecutor(def, this.entityClient)
           }),
           {}
         )
@@ -214,7 +218,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
       ? Object.entries(fg.customQueries).reduce(
           (acc, [name, def]) => ({
             ...acc,
-            [name]: new CustomQueryDefinitionExecutor(def, this.client)
+            [name]: new CustomQueryDefinitionExecutor(def, this.entityClient)
           }),
           {}
         )
@@ -223,7 +227,7 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
       ? Object.entries(fg.customCommands).reduce(
           (acc, [name, def]) => ({
             ...acc,
-            [name]: new CustomCommandDefinitionExecutor(def, this.client)
+            [name]: new CustomCommandDefinitionExecutor(def, this.entityClient)
           }),
           {}
         )

--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -45,7 +45,7 @@ type DefinitionExecutorMap = {
 /**
  *
  */
-export class PhenylRestApi<TM extends GeneralTypeMap>
+export class PhenylRestApi<TM extends GeneralTypeMap = GeneralTypeMap>
   implements RestApiHandler<TM>, GeneralRestApiHandler {
   readonly entityClient: EntityClient<ResponseEntityMapOf<TM>>;
   readonly sessionClient: SessionClient<AuthCommandMapOf<TM>>;

--- a/modules/rest-api/src/phenyl-rest-api.ts
+++ b/modules/rest-api/src/phenyl-rest-api.ts
@@ -57,12 +57,17 @@ export class PhenylRestApi<TM extends GeneralTypeMap>
     params: {
       entityClient: GeneralEntityClient;
       sessionClient?: GeneralSessionClient;
+      versionDiffPublisher?: VersionDiffPublisher;
     }
   ) {
     this.entityClient = params.entityClient;
+
     this.sessionClient =
       (params.sessionClient as SessionClient<AuthCommandMapOf<TM>>) ||
       this.entityClient.createSessionClient<AuthCommandMapOf<TM>>();
+
+    this.versionDiffPublisher = params.versionDiffPublisher;
+
     this.definitionExecutors = this.createDefinitionExecutors(fg);
   }
 


### PR DESCRIPTION
# Summary
## Abstract / Purpose
This PR makes type `FunctionalGroup` generic so that we can check the compatibility between FunctionalGroup and TypeMap.

```ts
interface MyTypeMap extends GeneralTypeMap {
  entities: {  book: any }
}

const fg: FunctionalGroup<MyTypeMap> = {
  nonUsers: { boook: new BookDefinition() }
}
```

Typo such as  `boook` in the example can be detected by this type system.

## Breaking changes
### Changes of public types
* type `FunctionalGroup` becomes a generic type.

## Changes of API
nothing.

## Additive changes (non-breaking)
* Type `GeneralFunctionalGroup` is added. (The same as original type `FunctionalGroup`)
* Type `UserEntityNameOf<TM>` and `NonUserEntityNameOf<TM>` are added.
* Class `PhenylRestApi` has `entityClient` property.
* Method `GeneralEntityClient#createSessionClient()` can accept broader types with overload
* Class `PhenylRestApi` accepts broader types in constructor.
 
## Refactoring
* `rest-api` no more depends on `central-state`.

## Bugfix
* `PhenylRestApi` accepts `versionDiffPublisher` argument at constructor.
