### PR TITLE
UserEntityNameOf<TM> is an intersection of AuthEntityNameOf<TM> and EntityNameOf<TM>

### DIFF
--- a/modules/interfaces/src/bound-request-response.ts
+++ b/modules/interfaces/src/bound-request-response.ts
@@ -1,6 +1,6 @@
 import {
   AuthCredentialsOf,
-  AuthEntityNameOf,
+  UserEntityNameOf,
   AuthSessionOf,
   RequestEntityOf,
   CustomCommandNameOf,
@@ -84,7 +84,7 @@ export type RequestDataWithTypeMapForResponse<
     N & EntityNameOf<TM>,
     N & CustomQueryNameOf<TM>,
     N & CustomCommandNameOf<TM>,
-    N & AuthEntityNameOf<TM>
+    N & UserEntityNameOf<TM>
   >,
   { method: MN }
 >;
@@ -101,7 +101,7 @@ export type RequestDataWithTypeMap<
   EN extends EntityNameOf<TM>,
   QN extends CustomQueryNameOf<TM>,
   CN extends CustomCommandNameOf<TM>,
-  AN extends AuthEntityNameOf<TM>
+  UN extends UserEntityNameOf<TM>
 > =
   | FindRequestData<EN>
   | FindOneRequestData<EN>
@@ -138,8 +138,8 @@ export type RequestDataWithTypeMap<
       CN,
       CustomCommandParamsOf<TM, CN & CustomCommandNameOf<TM>>
     >
-  | LoginRequestData<AN, AuthCredentialsOf<TM, AN & AuthEntityNameOf<TM>>>
-  | LogoutRequestData<AN>;
+  | LoginRequestData<UN, AuthCredentialsOf<TM, UN & UserEntityNameOf<TM>>>
+  | LogoutRequestData<UN>;
 
 /**
  * All possible `ResponseData` from the given `TypeMap`, `RequestMethodName` and `EveryNameOf<TM, MN>`.
@@ -153,7 +153,7 @@ export type ResponseDataWithTypeMap<
   N & EntityNameOf<TM>,
   N & CustomQueryNameOf<TM>,
   N & CustomCommandNameOf<TM>,
-  N & AuthEntityNameOf<TM>
+  N & UserEntityNameOf<TM>
 >[MN];
 
 type ResponseDataMapWithTypeMap<
@@ -161,7 +161,7 @@ type ResponseDataMapWithTypeMap<
   EN extends EntityNameOf<TM>,
   QN extends CustomQueryNameOf<TM>,
   CN extends CustomCommandNameOf<TM>,
-  AN extends AuthEntityNameOf<TM>
+  UN extends UserEntityNameOf<TM>
 > = {
   find: FindResponseData<ResponseEntityOf<TM, EN>>;
   findOne: FindOneResponseData<ResponseEntityOf<TM, EN>>;
@@ -183,9 +183,9 @@ type ResponseDataMapWithTypeMap<
     CustomCommandResultValueOf<TM, CN>
   >;
   login: LoginResponseData<
-    AN,
-    ResponseAuthUserOf<TM, AN>,
-    AuthSessionOf<TM, AN>
+    UN,
+    ResponseAuthUserOf<TM, UN>,
+    AuthSessionOf<TM, UN>
   >;
   logout: LogoutResponseData;
 };
@@ -195,7 +195,7 @@ type ResponseDataMapWithTypeMap<
  * - EntityName
  * - CustomQueryName
  * - CustomCommandName
- * - AuthEntityName
+ * - UserEntityName
  *
  * 2nd type parameter `MN` is `RequestMethodName`.
  * Only the names compatible with given method name are allowed.
@@ -242,5 +242,5 @@ export type EveryNameOf<
   : MN extends "runCustomCommand"
   ? CustomCommandNameOf<TM>
   : MN extends ("login" | "logout")
-  ? AuthEntityNameOf<TM>
+  ? UserEntityNameOf<TM>
   : string;

--- a/modules/interfaces/src/client.ts
+++ b/modules/interfaces/src/client.ts
@@ -387,13 +387,13 @@ export interface AuthClient<
   M extends GeneralReqResEntityMap,
   AM extends GeneralAuthCommandMap
 > extends GeneralAuthClient {
-  login<EN extends Key<AM>>(
+  login<EN extends Key<M> & Key<AM>>(
     command: LoginCommand<EN, AuthCredentials<AM, EN>>,
     sessionId?: string | null
   ): Promise<
     LoginCommandResult<EN, ResponseAuthUser<AM, EN, M>, AuthSessions<AM, EN>>
   >;
-  logout<EN extends Key<AM>>(
+  logout<EN extends Key<M> & Key<AM>>(
     command: LogoutCommand<EN>,
     sessionId?: string | null
   ): Promise<LogoutCommandResult>;

--- a/modules/interfaces/src/functional-group.ts
+++ b/modules/interfaces/src/functional-group.ts
@@ -23,7 +23,7 @@ export type CustomCommandDefinitions = {
 };
 
 export type UserDefinitions = {
-  [EntityName: string]: UserDefinition;
+  [UserEntityName: string]: UserDefinition;
 };
 
 export type GeneralNormalizedFunctionalGroup = {
@@ -35,7 +35,7 @@ export type GeneralNormalizedFunctionalGroup = {
 
 export interface NormalizedFunctionalGroup<TM extends GeneralTypeMap>
   extends GeneralNormalizedFunctionalGroup {
-  users: { [AN in UserEntityNameOf<TM>]: UserDefinition };
+  users: { [UN in UserEntityNameOf<TM>]: UserDefinition };
   nonUsers: { [EN in NonUserEntityNameOf<TM>]: EntityDefinition };
   customQueries: { [QN in CustomQueryNameOf<TM>]: CustomQueryDefinition };
   customCommands: { [CN in CustomCommandNameOf<TM>]: CustomCommandDefinition };

--- a/modules/interfaces/src/request-data-handlers.ts
+++ b/modules/interfaces/src/request-data-handlers.ts
@@ -1,6 +1,6 @@
 import {
   AuthCredentialsOf,
-  AuthEntityNameOf,
+  UserEntityNameOf,
   RequestEntityOf,
   CustomCommandNameOf,
   CustomCommandParamsOf,
@@ -82,11 +82,11 @@ export type RequestDataHandlers<TM extends GeneralTypeMap, T> = {
     command: CustomCommand<CN, CustomCommandParamsOf<TM, CN>>
   ): Promise<T>;
 
-  login<EN extends AuthEntityNameOf<TM>>(
+  login<EN extends UserEntityNameOf<TM>>(
     command: LoginCommand<EN, AuthCredentialsOf<TM, EN>>
   ): Promise<T>;
 
-  logout<EN extends AuthEntityNameOf<TM>>(
+  logout<EN extends UserEntityNameOf<TM>>(
     command: LogoutCommand<EN>
   ): Promise<T>;
 

--- a/modules/interfaces/src/type-map.ts
+++ b/modules/interfaces/src/type-map.ts
@@ -366,22 +366,24 @@ export type AuthCommandOf<
 > = TM["auths"][EN];
 
 /**
- * Name of user entities in given TypeMap.
+ * Name of auths in given TypeMap.
  */
-export type UserEntityNameOf<TM extends GeneralTypeMap> = Key<TM["auths"]>;
+export type AuthEntityNameOf<TM extends GeneralTypeMap> = Key<TM["auths"]>;
 
 /**
- * Name of auths in given TypeMap.
- * Alias for UserEntityNameOf
+ * Name of user entities in given TypeMap.
+ * It's an intersection of AuthEntityNameOf<TM> & EntityNameOf<TM>,
  */
-export type AuthEntityNameOf<TM extends GeneralTypeMap> = UserEntityNameOf<TM>;
+export type UserEntityNameOf<TM extends GeneralTypeMap> = AuthEntityNameOf<TM> &
+  EntityNameOf<TM>;
 
 /**
  * Name of non-user entities in given TypeMap.
+ * It's a subtraction of EntityNameOf<TM> from AuthEntityNameOf<TM>,
  */
 export type NonUserEntityNameOf<TM extends GeneralTypeMap> = Exclude<
   EntityNameOf<TM>,
-  UserEntityNameOf<TM>
+  AuthEntityNameOf<TM>
 >;
 
 /**

--- a/modules/interfaces/src/type-map.ts
+++ b/modules/interfaces/src/type-map.ts
@@ -147,9 +147,9 @@ type GeneralCustomInOut = {
 };
 
 /**
- * Key-value map of auth settings.
+ * Key-value map of user auth settings.
  * - Key: entityName
- * - Value: Auth setting
+ * - Value: User auth setting
  *
  * Library users implement concrete CustomMap in TypeMap.
  * "session" is optional and "Object" is set by default if not set in TypeMap.
@@ -351,9 +351,9 @@ export type CustomCommandResultValue<
 > = CustomResultValue<CM, CN>;
 
 /**
- * Key-value map of auth settings in given TypeMap.
- * - Key: entityName
- * - Value: Auth setting
+ * Key-value map of user auth settings in given TypeMap.
+ * - Key: user entityName
+ * - Value: User auth setting
  */
 export type AuthCommandMapOf<TM extends GeneralTypeMap> = TM["auths"];
 
@@ -366,15 +366,15 @@ export type AuthCommandOf<
 > = TM["auths"][EN];
 
 /**
- * Name of auths in given TypeMap.
+ * Name of user entities in given TypeMap.
  */
-export type AuthEntityNameOf<TM extends GeneralTypeMap> = Key<TM["auths"]>;
+export type UserEntityNameOf<TM extends GeneralTypeMap> = Key<TM["auths"]>;
 
 /**
  * Name of auths in given TypeMap.
- * Alias for AuthEntityNameOf
+ * Alias for UserEntityNameOf
  */
-export type UserEntityNameOf<TM extends GeneralTypeMap> = AuthEntityNameOf<TM>;
+export type AuthEntityNameOf<TM extends GeneralTypeMap> = UserEntityNameOf<TM>;
 
 /**
  * Name of non-user entities in given TypeMap.

--- a/modules/redux/src/middleware.ts
+++ b/modules/redux/src/middleware.ts
@@ -28,7 +28,8 @@ import {
   GeneralAuthCommandMap,
   Key,
   Entity,
-  ReqResEntityMapOf
+  ReqResEntityMapOf,
+  UserEntityNameOf
 } from "@phenyl/interfaces";
 import { GeneralUpdateOperation } from "sp2";
 
@@ -84,9 +85,11 @@ export class MiddlewareCreator {
             return handler.followAll(action);
 
           case "phenyl/login":
+            // @ts-ignore TODO: #287
             return handler.login(action);
 
           case "phenyl/logout":
+            // @ts-ignore TODO: #287
             return handler.logout(action);
 
           case "phenyl/patch":
@@ -501,8 +504,8 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
    * Login with credentials, then register the user.
    */
 
-  async login<AM extends GeneralAuthCommandMap, EN extends Key<AM>>(
-    action: LoginAction<EN, Object>
+  async login<UN extends UserEntityNameOf<TM>>(
+    action: LoginAction<UN, Object>
   ): Promise<GeneralAction> {
     const LocalStateUpdater = MiddlewareHandler.LocalStateUpdater;
     const command = action.payload;
@@ -529,21 +532,21 @@ export class MiddlewareHandler<TM extends GeneralTypeMap> {
 
     return this.assignToState(...ops);
   }
+
   /**
    * Remove the session in CentralState and reset the LocalState.
    */
-
-  async logout<AM extends GeneralAuthCommandMap, EN extends Key<AM>>(
-    action: LogoutAction<EN>
+  async logout<UN extends UserEntityNameOf<TM>>(
+    action: LogoutAction<UN>
   ): Promise<GeneralAction> {
     const command = action.payload;
     await this.client.logout(command, this.sessionId);
     return this.resetState();
   }
+
   /**
    * Apply the VersionDiff.
    */
-
   async patch(action: PatchAction): Promise<GeneralAction> {
     const LocalStateUpdater = MiddlewareHandler.LocalStateUpdater;
     const versionDiff = action.payload;

--- a/modules/utils/src/phenyl-rest-api-client.ts
+++ b/modules/utils/src/phenyl-rest-api-client.ts
@@ -1,6 +1,6 @@
 import {
   AuthCredentialsOf,
-  AuthEntityNameOf,
+  UserEntityNameOf,
   AuthSessionOf,
   RequestEntityOf,
   CustomCommand,
@@ -350,7 +350,7 @@ export abstract class PhenylRestApiClient<
   /**
    *
    */
-  async login<N extends AuthEntityNameOf<TM>>(
+  async login<N extends UserEntityNameOf<TM>>(
     command: LoginCommand<N, AuthCredentialsOf<TM, N>>,
     sessionId?: string | undefined | null
   ): Promise<
@@ -368,7 +368,7 @@ export abstract class PhenylRestApiClient<
   /**
    *
    */
-  async logout<N extends AuthEntityNameOf<TM>>(
+  async logout<N extends UserEntityNameOf<TM>>(
     command: LogoutCommand<N>,
     sessionId?: string | undefined | null
   ): Promise<LogoutCommandResult> {

--- a/modules/utils/src/switch-by-request-method.ts
+++ b/modules/utils/src/switch-by-request-method.ts
@@ -1,5 +1,5 @@
 import {
-  AuthEntityNameOf,
+  UserEntityNameOf,
   CustomCommandNameOf,
   CustomQueryNameOf,
   EntityNameOf,
@@ -13,10 +13,10 @@ export async function switchByRequestMethod<
   EN extends EntityNameOf<TM>,
   QN extends CustomQueryNameOf<TM>,
   CN extends CustomCommandNameOf<TM>,
-  AN extends AuthEntityNameOf<TM>,
+  UN extends UserEntityNameOf<TM>,
   T
 >(
-  reqData: RequestDataWithTypeMap<TM, EN, QN, CN, AN>,
+  reqData: RequestDataWithTypeMap<TM, EN, QN, CN, UN>,
   funcs: RequestDataHandlers<TM, T>
 ): Promise<T> {
   // prettier-ignore


### PR DESCRIPTION
# Summary
## Abstract / Purpose
This PR makes type `UserEntityNameOf<TM>` narrower so that it will become more suitable for its name.

```
interface MyTypeMap extends GeneralTypeMap {
  entities: { foo: any, bar: any },
  auths: { foo: any, baz: any }
}
```

`UserEntityNameOf<MyTypeMap>` had been `"foo"` | `"bar"`.
By  this change, it will be only `"foo"` because it's the only key that exists at `entities` and `auths`.


## Related issues

This will fix #286 

## Breaking changes
### Changes of public types
* Type `UserEntityNameOf<TM>` is changed, which isn't regarded as breaking change because this type is newly defined one since we published the latest npm packages.
* Also, `AuthCommandMapOf<TM>` is reverted to the original type at the last publish.
* Type definition of `FunctionalGroup`, redux `Middleware` and `RestApiClient` becomes narrower because they adopt this new `UserEntityNameOf<TM>`.

## Changes of API
nothing.

## Additive changes (non-breaking)
nothing.
 
## Refactoring
* Some type names are changed along with this change.

## Bugfix
nothing.
