### PR TITLE
Prepare two tsconfig files: tsconfig.json for coding and tsconfig.build.json for building.

### DIFF
--- a/modules/api-explorer-client/tsconfig.json
+++ b/modules/api-explorer-client/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "typeRoots": ["src/@types", "node_modules/@types"],
     "outDir": "lib",
+    "declaration": false,
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,

--- a/modules/api-explorer/package.json
+++ b/modules/api-explorer/package.json
@@ -18,7 +18,7 @@
   "types": "lib/PhenylApiExplorer.d.ts",
   "scripts": {
     "clean": "rm -rf lib",
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "start": "nodemon --exec upbin ts-node examples/index.ts --watch src --watch examples --extensions '.ts'",
     "test": "echo no test specified in phenyl-api-explorer",

--- a/modules/api-explorer/tsconfig.build.json
+++ b/modules/api-explorer/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/central-state/package.json
+++ b/modules/central-state/package.json
@@ -14,7 +14,7 @@
   "types": "lib/index.d.ts",
   "module": "lib/index.js",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {

--- a/modules/central-state/tsconfig.build.json
+++ b/modules/central-state/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/central-state/tsconfig.json
+++ b/modules/central-state/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/express/package.json
+++ b/modules/express/package.json
@@ -17,11 +17,11 @@
   "types": "lib/index.d.ts",
   "module": "lib/index.js",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/http-rules": "^1.1.1",

--- a/modules/express/tsconfig.build.json
+++ b/modules/express/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/express/tsconfig.json
+++ b/modules/express/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/http-client/package.json
+++ b/modules/http-client/package.json
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "test": "upbin nyc upbin mocha --require ts-node/register test/*.test.ts --color always",
     "type-check": "upbin tsc --noEmit"
   },

--- a/modules/http-client/tsconfig.build.json
+++ b/modules/http-client/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/http-client/tsconfig.json
+++ b/modules/http-client/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/http-rules/package.json
+++ b/modules/http-rules/package.json
@@ -15,11 +15,11 @@
   "module": "lib/index.js",
   "scripts": {
     "clean": "rm -rf lib",
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "test": "upbin nyc mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/interfaces": "^1.1.1",

--- a/modules/http-rules/tsconfig.build.json
+++ b/modules/http-rules/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/http-rules/tsconfig.json
+++ b/modules/http-rules/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/http-server/package.json
+++ b/modules/http-server/package.json
@@ -18,7 +18,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit"

--- a/modules/http-server/tsconfig.build.json
+++ b/modules/http-server/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/http-server/tsconfig.json
+++ b/modules/http-server/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/interfaces/package.json
+++ b/modules/interfaces/package.json
@@ -13,12 +13,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "upbin rimraf $(cat ../../.temporary-files)",
     "lint": "upbin eslint 'src/**/*.ts' 'type-test/**/*.ts' --fix",
     "test": "upbin tsc --noEmit type-test/**/*.ts",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "sp2": "^1.5.1"

--- a/modules/interfaces/tsconfig.build.json
+++ b/modules/interfaces/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/interfaces/tsconfig.json
+++ b/modules/interfaces/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/lambda-adapter/package.json
+++ b/modules/lambda-adapter/package.json
@@ -17,11 +17,11 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/http-rules": "^1.1.1",

--- a/modules/lambda-adapter/tsconfig.build.json
+++ b/modules/lambda-adapter/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/lambda-adapter/tsconfig.json
+++ b/modules/lambda-adapter/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/memory-db/package.json
+++ b/modules/memory-db/package.json
@@ -14,7 +14,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit"

--- a/modules/memory-db/tsconfig.build.json
+++ b/modules/memory-db/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/memory-db/tsconfig.json
+++ b/modules/memory-db/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/mongodb/package.json
+++ b/modules/mongodb/package.json
@@ -17,7 +17,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "pretest": "test/scripts/init-mongodb.sh",
     "test": "upbin mocha --require ts-node/register 'test/**/*.ts' --color always --timeout 20000 || (npm run posttest && exit 1)",

--- a/modules/mongodb/tsconfig.build.json
+++ b/modules/mongodb/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/mongodb/tsconfig.json
+++ b/modules/mongodb/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/redux/package.json
+++ b/modules/redux/package.json
@@ -18,7 +18,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit"

--- a/modules/redux/tsconfig.build.json
+++ b/modules/redux/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/redux/tsconfig.json
+++ b/modules/redux/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -13,12 +13,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "upbin rimraf $(cat ../../.temporary-files)",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/interfaces": "^1.1.1",

--- a/modules/rest-api/tsconfig.build.json
+++ b/modules/rest-api/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/rest-api/tsconfig.json
+++ b/modules/rest-api/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/standards/package.json
+++ b/modules/standards/package.json
@@ -17,7 +17,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin mocha --require ts-node/register 'test/**/*.ts' --color always",

--- a/modules/standards/tsconfig.build.json
+++ b/modules/standards/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/standards/tsconfig.json
+++ b/modules/standards/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/state/package.json
+++ b/modules/state/package.json
@@ -14,7 +14,7 @@
   "module": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "test": "upbin nyc upbin mocha --require ts-node/register test/*.ts --color always",
     "type-check": "upbin tsc --noEmit"

--- a/modules/state/tsconfig.build.json
+++ b/modules/state/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/state/tsconfig.json
+++ b/modules/state/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/utils/package.json
+++ b/modules/utils/package.json
@@ -16,12 +16,12 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "upbin rimraf $(cat ../../.temporary-files)",
     "lint": "upbin eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "test": "upbin nyc upbin mocha --require ts-node/register 'test/**/*.test.ts' --color always",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/interfaces": "^1.1.1",

--- a/modules/utils/tsconfig.build.json
+++ b/modules/utils/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/utils/tsconfig.json
+++ b/modules/utils/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/websocket-client/package.json
+++ b/modules/websocket-client/package.json
@@ -17,11 +17,11 @@
   },
   "types": "lib/esm/index.d.ts",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "clean": "rm -rf lib",
     "lint": "upbin eslint 'src/**/*.ts' --fix",
     "type-check": "upbin tsc --noEmit",
-    "watch": "upbin tsc --declaration --watch"
+    "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
     "@phenyl/utils": "^1.1.1",

--- a/modules/websocket-client/tsconfig.build.json
+++ b/modules/websocket-client/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/websocket-client/tsconfig.json
+++ b/modules/websocket-client/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/modules/websocket-server/package.json
+++ b/modules/websocket-server/package.json
@@ -18,7 +18,7 @@
   "types": "lib/index.d.ts",
   "module": "lib/index.js",
   "scripts": {
-    "build": "upbin tsc --declaration",
+    "build": "upbin tsc -p tsconfig.build.json",
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {

--- a/modules/websocket-server/tsconfig.build.json
+++ b/modules/websocket-server/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "rootDir": "src",
+    "outDir": "lib"
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*"]
 }

--- a/modules/websocket-server/tsconfig.json
+++ b/modules/websocket-server/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "lib"
+    "rootDir": "."
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "declaration": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "lib": ["esnext", "dom", "es5"],
     "module": "commonjs",
     "moduleResolution": "Node",
     "noUnusedLocals": true,
+    "rootDir": ".",
     "strict": true,
     "target": "es5"
-  },
-  "exclude": ["node_modules"]
+  }
 }


### PR DESCRIPTION
# Summary
This PR Improved how typescript config files are parsed and reflected.
Tsconfig files have not been applied to test files when using editors. This was caused by `rootDir` value which must have been `src`, not the root directory of each package. We couldn't set it to root directory because it would create a `lib/src` directory when they tried to build js files.
 To see the following link, I applied the method to avoid this problem.
https://stackoverflow.com/questions/35470511/setting-up-tsconfig-with-spec-test-folder
The method was to prepare two config files, one for coding and another for building.

# Breaking Changes
Nothing.