### PR TITLE
chore: add default option for createPhenylClient

### DIFF
--- a/modules/mongodb/src/create-phenyl-clients.ts
+++ b/modules/mongodb/src/create-phenyl-clients.ts
@@ -13,7 +13,7 @@ import { MongoDbConnection } from "./connection";
 
 export function createPhenylClients<TM extends GeneralTypeMap>(
   conn: MongoDbConnection,
-  options: PhenylEntityClientOptions<ResponseEntityMapOf<TM>>
+  options: PhenylEntityClientOptions<ResponseEntityMapOf<TM>> = {}
 ): PhenylClients<TM> {
   const entityClient = createEntityClient<ResponseEntityMapOf<TM>>(
     conn,


### PR DESCRIPTION
createPhenylClients required user to add option even if user does not need any options.
I've added default value so that 2nd argument is not required by user.