### PR TITLE
chore(deps): lock rest-api dependencies version

### DIFF
--- a/modules/rest-api/package.json
+++ b/modules/rest-api/package.json
@@ -21,8 +21,8 @@
     "watch": "upbin tsc -p tsconfig.build.json --watch"
   },
   "dependencies": {
-    "@phenyl/interfaces": "^1.1.1",
-    "@phenyl/utils": "^1.1.1"
+    "@phenyl/interfaces": "1.1.1",
+    "@phenyl/utils": "1.1.1"
   },
   "devDependencies": {
     "upbin": "^0.9.0"


### PR DESCRIPTION
#300

lock phenyl- dependencies version at rest-api module.